### PR TITLE
feat: FuzzyPaste 初期実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.build/
+.swiftpm/
+FuzzyPaste.app/
+*.xcodeproj/
+*.xcworkspace/
+DerivedData/
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# FuzzyPaste - Claude Code 開発ガイド
+
+## プロジェクト概要
+
+macOSネイティブのクリップボードマネージャー。Clipyの改善版で、fuzzy searchによるインクリメンタル検索が最大の特徴。
+
+## ビルド・実行コマンド
+
+- `make run` — デバッグビルド & 実行
+- `make release` — リリースビルド
+- `make bundle` — .appバンドル作成
+- `make clean` — クリーン
+- `swift build` — ビルドのみ
+
+## 技術スタック
+
+- Swift / AppKit / Swift Package Manager
+- Xcode IDEは使わない (エディタ + ターミナル)
+- 対象: macOS 13+
+
+## コーディング規約
+
+- Swift 6.1 の concurrency モデルに従う (`@MainActor` など)
+- AppKit ベース。UIKit は使わない
+- SwiftUI は部分的に利用可 (NSHostingView 経由)
+
+## 進捗管理
+
+- **PROGRESS.md を常に最新の状態に保つこと**
+- 機能の実装を開始したら、該当項目を `[~]` (進行中) に更新する
+- 機能の実装が完了したら、該当項目を `[x]` (完了) に更新する
+- 新しいタスクが発生したら PROGRESS.md に追記する
+- 作業の開始時と終了時に PROGRESS.md を確認・更新する

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+APP_NAME = FuzzyPaste
+BUILD_DIR = .build/release
+APP_BUNDLE = $(APP_NAME).app
+
+.PHONY: build run clean bundle
+
+build:
+	swift build
+
+release:
+	swift build -c release
+
+run: build
+	.build/debug/$(APP_NAME)
+
+bundle: release
+	rm -rf $(APP_BUNDLE)
+	mkdir -p $(APP_BUNDLE)/Contents/MacOS
+	mkdir -p $(APP_BUNDLE)/Contents/Resources
+	cp $(BUILD_DIR)/$(APP_NAME) $(APP_BUNDLE)/Contents/MacOS/
+	cp Resources/Info.plist $(APP_BUNDLE)/Contents/
+	@echo "Created $(APP_BUNDLE)"
+
+clean:
+	swift package clean
+	rm -rf $(APP_BUNDLE)

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,51 @@
+# FuzzyPaste 開発進捗
+
+## ステータス凡例
+
+- [ ] 未着手
+- [~] 進行中
+- [x] 完了
+
+## プロジェクト初期化
+
+- [x] Swift Package Manager セットアップ (`Package.swift`)
+- [x] ディレクトリ構成作成
+- [x] Makefile 作成 (build / run / bundle / clean)
+- [x] Info.plist 作成 (LSUIElement=true)
+- [x] エントリーポイント (`main.swift`)
+- [x] AppDelegate 最小実装 (メニューバーアイコン表示)
+- [x] .gitignore
+- [x] README.md
+- [x] PROGRESS.md
+
+## コア機能
+
+- [x] ClipboardMonitor — NSPasteboardポーリング (0.5秒間隔)、変更検知
+- [x] HistoryStore — 履歴の永続化 (JSON、最大500件、FIFO)
+- [x] FuzzyMatcher — fuzzy searchアルゴリズム
+- [x] PasteHelper — 選択アイテムのペースト実行
+
+## UI
+
+- [x] SearchWindow — ポップアップ検索ウィンドウ (テキスト入力 + リスト表示)
+- [x] HotkeyManager — グローバルホットキー登録 (Cmd+Shift+V)
+- [x] カーソル位置基準のウィンドウ表示
+- [x] フロストガラス風デザイン (NSVisualEffectView)
+- [x] ヒントバー (⏎ Paste / ⌘C Copy / esc Close)
+- [x] Enter でペースト、Cmd+C でコピーのみ
+- [x] フォーカス離脱時にウィンドウ自動閉じ
+- [x] コードレビュー＆リファクタリング (92点)
+- [x] 全ソースファイルへのコメント追加
+- [ ] メニューバーメニュー改善 (履歴一覧表示など)
+
+## 追加機能
+
+- [ ] FavoritesStore — お気に入り管理
+- [ ] 自動起動 (SMAppService)
+- [ ] アクセシビリティ権限チェック・リクエスト
+
+## 配布
+
+- [ ] リリースビルド最適化
+- [ ] DMG / zip パッケージング
+- [ ] GitHub Releases 設定

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "FuzzyPaste",
+    platforms: [
+        .macOS(.v13)
+    ],
+    targets: [
+        .executableTarget(
+            name: "FuzzyPaste",
+            path: "Sources/FuzzyPaste"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+# FuzzyPaste
+
+macOSネイティブのクリップボードマネージャー。[Clipy](https://github.com/Clipy/Clipy)の改善版として、**fuzzy searchによるインクリメンタル検索**を最大の特徴とする。
+
+## 特徴
+
+- **fuzzy search** — インクリメンタルにクリップボード履歴を絞り込み
+- **メニューバー常駐** — Dockに表示せず、メニューバーアイコンのみで動作
+- **グローバルホットキー** — `Cmd+Shift+V` で検索UIをポップアップ表示
+- **お気に入り** — よく使うテキストをスター付きで永続保存
+- **自動起動** — ログイン時に自動起動
+
+## 技術スタック
+
+| 項目 | 内容 |
+|---|---|
+| 言語 | Swift |
+| フレームワーク | AppKit (UIはSwiftUIも部分的に利用可) |
+| ビルド | Swift Package Manager (`swift build`) |
+| 対象OS | macOS 13+ |
+
+Xcode IDEは使わず、任意のエディタ + ターミナルで開発。
+
+## 必要環境
+
+- macOS 13 (Ventura) 以降
+- Xcode Command Line Tools (Swiftコンパイラ + macOS SDK)
+
+## ビルド・実行
+
+```sh
+# デバッグビルド & 実行
+make run
+
+# リリースビルド
+make release
+
+# .appバンドル作成
+make bundle
+
+# クリーン
+make clean
+```
+
+## アーキテクチャ
+
+```
+FuzzyPaste.app
+├── AppDelegate          — アプリのライフサイクル管理、メニューバー常駐
+├── ClipboardMonitor     — NSPasteboardのポーリング、変更検知
+├── HistoryStore         — 履歴の保存/読込/削除 (最大500件)
+├── FavoritesStore       — お気に入りの管理
+├── FuzzyMatcher         — fuzzy searchアルゴリズム
+├── SearchWindow         — ポップアップ検索UI (テキスト入力 + リスト表示)
+├── HotkeyManager        — グローバルホットキー登録 (Cmd+Shift+V)
+└── PasteHelper          — 選択アイテムのペースト実行
+```
+
+## データ保存先
+
+```
+~/Library/Application Support/FuzzyPaste/
+├── history.json       — クリップボード履歴 (最大500件、FIFO)
+└── favorites.json     — お気に入りアイテム (件数制限なし)
+```
+
+## 権限
+
+- **アクセシビリティ権限** — グローバルホットキー、ペースト操作に必要
+- 初回起動時にユーザーに許可を求めるダイアログを表示
+
+## 配布
+
+- GitHub Releases で .app を zip/DMG として配布
+- Homebrew Cask での配布も将来的に対応
+
+## ライセンス
+
+MIT

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>FuzzyPaste</string>
+    <key>CFBundleDisplayName</key>
+    <string>FuzzyPaste</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.gehnmaisoda.FuzzyPaste</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleExecutable</key>
+    <string>FuzzyPaste</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>

--- a/Sources/FuzzyPaste/AppDelegate.swift
+++ b/Sources/FuzzyPaste/AppDelegate.swift
@@ -1,0 +1,87 @@
+import AppKit
+
+/// アプリ全体のライフサイクルを管理する司令塔。
+/// メニューバー常駐、クリップボード監視、ホットキー、検索ウィンドウを統括する。
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private static let appVersion = "0.1.0"
+
+    private var statusItem: NSStatusItem!
+    private let clipboardMonitor = ClipboardMonitor()
+    private let historyStore = HistoryStore()
+    private let hotkeyManager = HotkeyManager()
+    private var searchWindow: SearchWindow?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        setupMenuBar()
+        startClipboardMonitor()
+        setupHotkey()
+    }
+
+    // MARK: - クリップボード監視
+
+    private func startClipboardMonitor() {
+        clipboardMonitor.onNewClip = { [weak self] text in
+            self?.historyStore.add(text)
+        }
+        clipboardMonitor.start()
+    }
+
+    // MARK: - グローバルホットキー
+
+    private func setupHotkey() {
+        hotkeyManager.onHotkey = { [weak self] in
+            self?.toggleSearchWindow()
+        }
+        hotkeyManager.register()
+    }
+
+    // MARK: - 検索ウィンドウ
+
+    /// Cmd+Shift+V で呼ばれるトグル処理。
+    /// 表示中なら閉じる、非表示なら開く。
+    private func toggleSearchWindow() {
+        if let window = searchWindow, window.isVisible {
+            window.dismiss()
+            return
+        }
+
+        // ウィンドウは一度作ったら再利用する（毎回生成しない）
+        let window = searchWindow ?? createSearchWindow()
+        searchWindow = window
+        window.show(items: historyStore.items)
+    }
+
+    private func createSearchWindow() -> SearchWindow {
+        let window = SearchWindow()
+        window.onPaste = { [weak self] text, previousApp in
+            // 自分のペーストを履歴に重複登録しないよう、モニターに無視指示
+            self?.clipboardMonitor.ignoreNext(text)
+            PasteHelper.paste(text, previousApp: previousApp)
+        }
+        window.onCopy = { [weak self] text in
+            self?.clipboardMonitor.ignoreNext(text)
+            PasteHelper.copyToClipboard(text)
+        }
+        return window
+    }
+
+    // MARK: - メニューバー
+
+    private func setupMenuBar() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+
+        if let button = statusItem.button {
+            button.image = NSImage(
+                systemSymbolName: "scissors",
+                accessibilityDescription: "FuzzyPaste"
+            )
+        }
+
+        let menu = NSMenu()
+        menu.addItem(NSMenuItem(title: "FuzzyPaste v\(Self.appVersion)", action: nil, keyEquivalent: ""))
+        menu.addItem(NSMenuItem.separator())
+        menu.addItem(NSMenuItem(title: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
+        statusItem.menu = menu
+    }
+}

--- a/Sources/FuzzyPaste/ClipboardMonitor.swift
+++ b/Sources/FuzzyPaste/ClipboardMonitor.swift
@@ -1,0 +1,62 @@
+import AppKit
+
+/// システムクリップボード (NSPasteboard.general) を定期的にポーリングし、
+/// 新しいテキストがコピーされたことを検知するモニター。
+///
+/// macOS にはクリップボード変更の通知APIがないため、
+/// changeCount を定期チェックする方式を採用（Clipy等も同じ手法）。
+@MainActor
+final class ClipboardMonitor {
+    private static let pollInterval: TimeInterval = 0.5
+
+    private var timer: Timer?
+    /// changeCount はクリップボードが更新されるたびにインクリメントされる整数。
+    /// 前回の値と比較することで変更を検知する。
+    private var lastChangeCount: Int
+    private let pasteboard = NSPasteboard.general
+    /// 自分自身がペーストしたテキストを履歴に重複登録しないために、
+    /// 次に検知するテキストを一時的に無視するための値。
+    private var textToIgnore: String?
+    var onNewClip: ((String) -> Void)?
+
+    init() {
+        lastChangeCount = pasteboard.changeCount
+    }
+
+    func start() {
+        timer = Timer.scheduledTimer(withTimeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.checkForChanges()
+            }
+        }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    /// 次にこのテキストが検知されたら無視する。
+    /// ペースト操作で自分がクリップボードに書き込んだテキストを、
+    /// 新しいコピーとして重複検知しないための仕組み。
+    func ignoreNext(_ text: String) {
+        textToIgnore = text
+    }
+
+    private func checkForChanges() {
+        let currentCount = pasteboard.changeCount
+        guard currentCount != lastChangeCount else { return }
+        lastChangeCount = currentCount
+
+        guard let text = pasteboard.string(forType: .string), !text.isEmpty else { return }
+
+        // 自分がペーストしたテキストなら無視して、フラグをリセット
+        if let ignore = textToIgnore, text == ignore {
+            textToIgnore = nil
+            return
+        }
+        textToIgnore = nil
+
+        onNewClip?(text)
+    }
+}

--- a/Sources/FuzzyPaste/FuzzyMatcher.swift
+++ b/Sources/FuzzyPaste/FuzzyMatcher.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// fuzzy search アルゴリズム。
+/// クエリの各文字が対象文字列に「順番通りに」含まれていればマッチとみなす。
+///
+/// 例: クエリ "hlo" は "hello world" にマッチする（h...l...o の順で見つかる）
+/// 例: クエリ "olh" は "hello world" にマッチしない（順番が違う）
+enum FuzzyMatcher {
+    /// マッチ判定とスコア計算。マッチしなければ nil を返す。
+    ///
+    /// スコアリング: 連続一致にボーナスを与える。
+    /// - 1文字目の連続一致 → +1
+    /// - 2文字目の連続一致 → +2（累積）
+    /// - 途切れたらリセット
+    /// これにより "hello" で検索したとき、"hello world" が "h.e" より上位にくる。
+    static func match(query: String, target: String) -> Int? {
+        let query = query.lowercased()
+        let target = target.lowercased()
+
+        var score = 0
+        var consecutive = 0
+        var targetIndex = target.startIndex
+
+        for queryChar in query {
+            var found = false
+            while targetIndex < target.endIndex {
+                if target[targetIndex] == queryChar {
+                    consecutive += 1
+                    score += consecutive
+                    targetIndex = target.index(after: targetIndex)
+                    found = true
+                    break
+                }
+                consecutive = 0
+                targetIndex = target.index(after: targetIndex)
+            }
+            if !found { return nil }
+        }
+        return score
+    }
+
+    /// クエリでアイテム一覧をフィルタリングし、スコア降順でソートして返す。
+    /// クエリが空の場合は全件をそのまま返す。
+    static func filter(query: String, items: [ClipItem]) -> [ClipItem] {
+        if query.isEmpty { return items }
+        return items
+            .compactMap { item -> (item: ClipItem, score: Int)? in
+                guard let score = match(query: query, target: item.text) else { return nil }
+                return (item, score)
+            }
+            .sorted { $0.score > $1.score }
+            .map(\.item)
+    }
+}

--- a/Sources/FuzzyPaste/HistoryStore.swift
+++ b/Sources/FuzzyPaste/HistoryStore.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// クリップボード履歴の1エントリ。
+/// JSON で永続化するため Codable に準拠。
+struct ClipItem: Codable, Identifiable {
+    let id: UUID
+    let text: String
+    let copiedAt: Date
+
+    init(text: String) {
+        self.id = UUID()
+        self.text = text
+        self.copiedAt = Date()
+    }
+}
+
+/// クリップボード履歴をメモリ上に保持し、JSON ファイルで永続化するストア。
+/// 最大 500 件を FIFO で管理。同じテキストの重複は先頭に移動して統合する。
+///
+/// 保存先: ~/Library/Application Support/FuzzyPaste/history.json
+@MainActor
+final class HistoryStore {
+    private static let maxItems = 500
+
+    private(set) var items: [ClipItem] = []
+    private let fileURL: URL
+
+    init() {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let dir = appSupport.appendingPathComponent("FuzzyPaste")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        fileURL = dir.appendingPathComponent("history.json")
+        load()
+    }
+
+    func add(_ text: String) {
+        // 同じテキストが既にあれば削除（重複排除）→ 先頭に新規挿入
+        items.removeAll { $0.text == text }
+        items.insert(ClipItem(text: text), at: 0)
+
+        // 上限を超えた古いエントリを切り捨て
+        if items.count > Self.maxItems {
+            items = Array(items.prefix(Self.maxItems))
+        }
+        save()
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        items = (try? decoder.decode([ClipItem].self, from: data)) ?? []
+    }
+
+    /// アトミック書き込みにより、書き込み中にクラッシュしてもファイルが壊れない
+    private func save() {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(items) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/Sources/FuzzyPaste/HotkeyManager.swift
+++ b/Sources/FuzzyPaste/HotkeyManager.swift
@@ -1,0 +1,74 @@
+import AppKit
+import Carbon
+
+/// グローバルホットキー (Cmd+Shift+V) の登録・管理を担当。
+///
+/// Carbon の RegisterEventHotKey API を使用。理由:
+/// - NSEvent.addGlobalMonitorForEvents はイベントを「監視」するだけで消費しない。
+///   そのため、ホットキーが元アプリにも伝わり「V」が入力されてしまう。
+/// - Carbon API はイベントを横取りするため、この問題が起きない。
+/// - Carbon API は deprecated だが、代替となる純 Swift API がまだ存在しない。
+///
+/// ※ C関数ポインタをコールバックとして使うため、static 変数でインスタンスを保持する
+///   シングルトン的パターンを採用。複数インスタンスは想定しない。
+@MainActor
+final class HotkeyManager {
+    private static let hotkeySignature = OSType(0x4650_5354) // FourCC: "FPST" (FuzzyPaSte)
+    private static let hotkeyID: UInt32 = 1
+
+    private var hotKeyRef: EventHotKeyRef?
+    var onHotkey: (() -> Void)?
+
+    /// C コールバックからインスタンスにアクセスするための参照。
+    /// Carbon API は C 関数ポインタしかコールバックに使えないため、
+    /// この static 変数経由でSwiftインスタンスに到達する。
+    fileprivate static var instance: HotkeyManager?
+
+    func register() {
+        HotkeyManager.instance = self
+
+        // キーボードイベントハンドラをインストール
+        var eventType = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+        let handlerStatus = InstallEventHandler(
+            GetApplicationEventTarget(), hotKeyHandler, 1, &eventType, nil, nil
+        )
+        if handlerStatus != noErr {
+            NSLog("[FuzzyPaste] Failed to install event handler: \(handlerStatus)")
+        }
+
+        // Cmd+Shift+V をグローバルホットキーとして登録
+        let hotKeyID = EventHotKeyID(signature: Self.hotkeySignature, id: Self.hotkeyID)
+        let modifiers = UInt32(cmdKey | shiftKey)
+        let registerStatus = RegisterEventHotKey(
+            UInt32(PasteHelper.vKeyCode), modifiers, hotKeyID,
+            GetApplicationEventTarget(), 0, &hotKeyRef
+        )
+        if registerStatus != noErr {
+            NSLog("[FuzzyPaste] Failed to register hotkey: \(registerStatus)")
+        }
+    }
+
+    func unregister() {
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+            self.hotKeyRef = nil
+        }
+        HotkeyManager.instance = nil
+    }
+}
+
+/// Carbon API から呼ばれる C 関数コールバック。
+/// ホットキーが押されたときに発火し、static 変数経由でSwift側に通知する。
+private func hotKeyHandler(
+    nextHandler: EventHandlerCallRef?,
+    event: EventRef?,
+    userData: UnsafeMutableRawPointer?
+) -> OSStatus {
+    MainActor.assumeIsolated {
+        HotkeyManager.instance?.onHotkey?()
+    }
+    return noErr
+}

--- a/Sources/FuzzyPaste/PasteHelper.swift
+++ b/Sources/FuzzyPaste/PasteHelper.swift
@@ -1,0 +1,51 @@
+import AppKit
+import CoreGraphics
+
+/// クリップボードへの書き込みと、Cmd+V シミュレートによるペースト操作を担当。
+///
+/// ペーストの流れ:
+/// 1. テキストをクリップボードにセット
+/// 2. 元アプリをアクティブにする
+/// 3. 少し待ってからCGEvent でCmd+V キー入力をシミュレート
+///
+/// ※ CGEvent の投稿にはアクセシビリティ権限が必要。
+///   システム設定 → プライバシーとセキュリティ → アクセシビリティ で許可する。
+@MainActor
+enum PasteHelper {
+    /// V キーの仮想キーコード。HotkeyManager でも参照するため internal アクセス。
+    static let vKeyCode: CGKeyCode = 9
+
+    /// 元アプリがアクティブになるまで待つ時間。
+    /// 短すぎるとアプリ切替が完了する前にキーイベントが飛んでしまう。
+    private static let activationDelay: Duration = .milliseconds(100)
+
+    /// テキストをクリップボードにセットし、元アプリにフォーカスを戻してからCmd+Vをシミュレート
+    static func paste(_ text: String, previousApp: NSRunningApplication?) {
+        copyToClipboard(text)
+        previousApp?.activate()
+
+        Task { @MainActor in
+            try? await Task.sleep(for: activationDelay)
+            simulatePaste()
+        }
+    }
+
+    /// テキストをクリップボードにセットする（ペーストはしない）
+    static func copyToClipboard(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+
+    /// CGEvent を使って Cmd+V キー押下をシミュレート。
+    /// これにより、アクティブなアプリにペーストが実行される。
+    private static func simulatePaste() {
+        let source = CGEventSource(stateID: .hidSystemState)
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true)
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false)
+        keyDown?.flags = .maskCommand
+        keyUp?.flags = .maskCommand
+        keyDown?.post(tap: .cghidEventTap)
+        keyUp?.post(tap: .cghidEventTap)
+    }
+}

--- a/Sources/FuzzyPaste/SearchWindow.swift
+++ b/Sources/FuzzyPaste/SearchWindow.swift
@@ -1,0 +1,423 @@
+import AppKit
+
+/// フォーカスを受け取らない NSTableView。
+/// 検索フィールドに常にフォーカスを維持するために使用。
+/// これにより、テーブルをクリックしてもフォーカスが移動せず、
+/// キーボード操作が常に検索フィールド経由で処理される。
+@MainActor
+private final class NonFocusTableView: NSTableView {
+    override var acceptsFirstResponder: Bool { false }
+}
+
+/// ポップアップ検索ウィンドウ。Cmd+Shift+V で表示される。
+///
+/// 構成:
+/// ┌──────────────────────────┐
+/// │ 🔍 検索フィールド         │ ← fuzzy search 入力
+/// ├──────────────────────────┤
+/// │ 履歴アイテム1             │ ← ↑↓キーで選択
+/// │ 履歴アイテム2             │
+/// │ ...                      │
+/// ├──────────────────────────┤
+/// │ ⏎ Paste  ⌘C Copy  esc   │ ← ショートカットヒント
+/// └──────────────────────────┘
+///
+/// NSPanel を使用することで、他アプリの上にフローティング表示できる。
+@MainActor
+final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, NSTableViewDelegate {
+    // MARK: - 定数
+
+    /// macOS の仮想キーコード
+    private enum KeyCode {
+        static let c: UInt16 = 8
+        static let a: UInt16 = 0
+    }
+
+    /// レイアウト定数。デザイン調整はここを変えるだけでOK。
+    private enum Layout {
+        static let windowSize = NSSize(width: 480, height: 360)
+        static let cornerRadius: CGFloat = 12
+        static let searchFontSize: CGFloat = 18
+        static let cellFontSize: CGFloat = 13
+        static let hintFontSize: CGFloat = 11
+        static let rowHeight: CGFloat = 36
+        static let windowPadding: CGFloat = 12
+        static let cellPadding: CGFloat = 16
+        static let searchHeight: CGFloat = 36
+        static let hintBarHeight: CGFloat = 28
+        static let iconSize: CGFloat = 20
+        static let sectionGap: CGFloat = 8
+        static let iconInset: CGFloat = 4
+        static let iconTextGap: CGFloat = 8
+    }
+
+    // MARK: - プロパティ
+
+    private let searchField = NSTextField()
+    private let scrollView = NSScrollView()
+    private let tableView = NonFocusTableView()
+
+    private var allItems: [ClipItem] = []
+    private var filteredItems: [ClipItem] = []
+    /// ウィンドウを開く直前にアクティブだったアプリ。ペースト先として使用。
+    private var previousApp: NSRunningApplication?
+    /// Enter で選択 → ペースト実行
+    var onPaste: ((String, NSRunningApplication?) -> Void)?
+    /// Cmd+C で選択 → クリップボードにコピーのみ
+    var onCopy: ((String) -> Void)?
+
+    init() {
+        super.init(
+            contentRect: NSRect(origin: .zero, size: Layout.windowSize),
+            styleMask: [.titled, .fullSizeContentView, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        level = .floating
+        isMovableByWindowBackground = true
+        titlebarAppearsTransparent = true
+        titleVisibility = .hidden
+        isReleasedWhenClosed = false
+        hidesOnDeactivate = false
+        // 角丸ウィンドウのために背景を透明にする
+        isOpaque = false
+        backgroundColor = .clear
+        setupUI()
+    }
+
+    // MARK: - UI Setup
+
+    private func setupUI() {
+        // すりガラス効果の背景。Spotlight / Raycast 風のモダンな見た目。
+        let visualEffect = NSVisualEffectView()
+        visualEffect.material = .sheet
+        visualEffect.state = .active
+        visualEffect.wantsLayer = true
+        visualEffect.layer?.cornerRadius = Layout.cornerRadius
+        visualEffect.layer?.masksToBounds = true
+        contentView = visualEffect
+
+        let searchContainer = setupSearchField(in: visualEffect)
+        let separator = addSeparator(in: visualEffect, below: searchContainer)
+        setupTableView(in: visualEffect, below: separator)
+        setupHintBar(in: visualEffect)
+    }
+
+    private func setupSearchField(in container: NSView) -> NSView {
+        let searchContainer = NSView()
+        searchContainer.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(searchContainer)
+
+        let searchIcon = NSImageView()
+        searchIcon.image = NSImage(systemSymbolName: "magnifyingglass", accessibilityDescription: nil)
+        searchIcon.contentTintColor = .tertiaryLabelColor
+        searchIcon.translatesAutoresizingMaskIntoConstraints = false
+        searchContainer.addSubview(searchIcon)
+
+        searchField.placeholderString = "Type to search..."
+        searchField.font = .systemFont(ofSize: Layout.searchFontSize, weight: .light)
+        searchField.focusRingType = .none
+        searchField.isBordered = false
+        searchField.drawsBackground = false
+        searchField.delegate = self
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+        searchContainer.addSubview(searchField)
+
+        NSLayoutConstraint.activate([
+            searchContainer.topAnchor.constraint(equalTo: container.topAnchor, constant: Layout.sectionGap),
+            searchContainer.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: Layout.windowPadding),
+            searchContainer.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -Layout.windowPadding),
+            searchContainer.heightAnchor.constraint(equalToConstant: Layout.searchHeight),
+
+            searchIcon.leadingAnchor.constraint(equalTo: searchContainer.leadingAnchor, constant: Layout.iconInset),
+            searchIcon.centerYAnchor.constraint(equalTo: searchContainer.centerYAnchor),
+            searchIcon.widthAnchor.constraint(equalToConstant: Layout.iconSize),
+            searchIcon.heightAnchor.constraint(equalToConstant: Layout.iconSize),
+
+            searchField.leadingAnchor.constraint(equalTo: searchIcon.trailingAnchor, constant: Layout.iconTextGap),
+            searchField.trailingAnchor.constraint(equalTo: searchContainer.trailingAnchor),
+            searchField.centerYAnchor.constraint(equalTo: searchContainer.centerYAnchor),
+        ])
+
+        return searchContainer
+    }
+
+    private func addSeparator(in container: NSView, below anchor: NSView) -> NSBox {
+        let separator = NSBox()
+        separator.boxType = .separator
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(separator)
+
+        NSLayoutConstraint.activate([
+            separator.topAnchor.constraint(equalTo: anchor.bottomAnchor, constant: Layout.sectionGap),
+            separator.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        ])
+        return separator
+    }
+
+    private func setupTableView(in container: NSView, below separator: NSBox) {
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("ClipColumn"))
+        column.title = ""
+        tableView.addTableColumn(column)
+        tableView.headerView = nil
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.rowHeight = Layout.rowHeight
+        tableView.backgroundColor = .clear
+        tableView.intercellSpacing = NSSize(width: 0, height: 1)
+        tableView.selectionHighlightStyle = .regular
+        tableView.doubleAction = #selector(tableDoubleClicked)
+        tableView.target = self
+        tableView.style = .plain
+
+        scrollView.documentView = tableView
+        scrollView.hasVerticalScroller = true
+        scrollView.scrollerStyle = .overlay
+        scrollView.drawsBackground = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(scrollView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: separator.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        ])
+    }
+
+    private func setupHintBar(in container: NSView) {
+        let hintBar = NSView()
+        hintBar.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(hintBar)
+
+        let hintSeparator = NSBox()
+        hintSeparator.boxType = .separator
+        hintSeparator.translatesAutoresizingMaskIntoConstraints = false
+        hintBar.addSubview(hintSeparator)
+
+        let hintLabel = NSTextField(labelWithString: "⏎ Paste    ⌘C Copy    esc Close")
+        hintLabel.font = .systemFont(ofSize: Layout.hintFontSize)
+        hintLabel.textColor = .tertiaryLabelColor
+        hintLabel.translatesAutoresizingMaskIntoConstraints = false
+        hintBar.addSubview(hintLabel)
+
+        NSLayoutConstraint.activate([
+            scrollView.bottomAnchor.constraint(equalTo: hintBar.topAnchor),
+
+            hintBar.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            hintBar.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            hintBar.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            hintBar.heightAnchor.constraint(equalToConstant: Layout.hintBarHeight),
+
+            hintSeparator.topAnchor.constraint(equalTo: hintBar.topAnchor),
+            hintSeparator.leadingAnchor.constraint(equalTo: hintBar.leadingAnchor),
+            hintSeparator.trailingAnchor.constraint(equalTo: hintBar.trailingAnchor),
+
+            hintLabel.centerYAnchor.constraint(equalTo: hintBar.centerYAnchor),
+            hintLabel.centerXAnchor.constraint(equalTo: hintBar.centerXAnchor),
+        ])
+    }
+
+    // MARK: - Show / Dismiss
+
+    func show(items: [ClipItem]) {
+        // ウィンドウを開く前にアクティブなアプリを記録（ペースト先として使う）
+        previousApp = NSWorkspace.shared.frontmostApplication
+        allItems = items
+        searchField.stringValue = ""
+        filteredItems = items
+        tableView.reloadData()
+
+        positionNearCursor()
+        makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        makeFirstResponder(searchField)
+
+        // 先頭のアイテムを自動選択
+        if !filteredItems.isEmpty {
+            tableView.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+        }
+    }
+
+    func dismiss() {
+        orderOut(nil)
+        previousApp?.activate()
+    }
+
+    /// マウスカーソル付近にウィンドウを配置。画面からはみ出さないよう調整する。
+    private func positionNearCursor() {
+        let mouseLocation = NSEvent.mouseLocation
+        let windowSize = frame.size
+
+        guard let screen = NSScreen.screens.first(where: { NSMouseInRect(mouseLocation, $0.frame, false) })
+            ?? NSScreen.main else { return }
+        let screenFrame = screen.visibleFrame
+
+        var x = mouseLocation.x
+        var y = mouseLocation.y
+
+        // 画面端でクリッピング
+        x = x.clamped(to: screenFrame.minX...(screenFrame.maxX - windowSize.width))
+        // macOS の座標系は左下原点。ウィンドウ上端をカーソル位置に合わせる。
+        y = (y - windowSize.height).clamped(to: screenFrame.minY...(screenFrame.maxY - windowSize.height))
+
+        setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    // MARK: - Window lifecycle
+
+    /// ウィンドウからフォーカスが外れたら自動的に閉じる。
+    /// 他のアプリをクリックしたり、別のウィンドウに切り替えた時に発火。
+    override func resignKey() {
+        super.resignKey()
+        dismiss()
+    }
+
+    // MARK: - Key handling
+
+    /// performKeyEquivalent は AppKit のキーイベント処理で最初に呼ばれるため、
+    /// テキストフィールドのデフォルト動作（Cmd+C でフィールド内テキストをコピー）
+    /// より先に、アプリ独自のショートカットを処理できる。
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+
+        // Cmd+C → 選択中のアイテムをクリップボードにコピー
+        if event.keyCode == KeyCode.c && flags == .command {
+            copyCurrentItem()
+            return true
+        }
+
+        // Cmd+A → 検索フィールドの全選択
+        if event.keyCode == KeyCode.a && flags == .command {
+            if let editor = searchField.currentEditor() {
+                editor.selectAll(nil)
+                return true
+            }
+        }
+
+        return super.performKeyEquivalent(with: event)
+    }
+
+    // MARK: - NSTextFieldDelegate
+
+    /// 検索フィールドの入力が変わるたびにfuzzy searchでフィルタリング
+    func controlTextDidChange(_ obj: Notification) {
+        let query = searchField.stringValue
+        filteredItems = FuzzyMatcher.filter(query: query, items: allItems)
+        tableView.reloadData()
+        if !filteredItems.isEmpty {
+            tableView.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+        }
+    }
+
+    /// 検索フィールド内での特殊キー（Enter, Esc, ↑↓）を処理。
+    /// true を返すと「処理済み」としてデフォルト動作を抑制する。
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        if commandSelector == #selector(insertNewline(_:)) {
+            selectCurrentItem()
+            return true
+        }
+        if commandSelector == #selector(cancelOperation(_:)) {
+            dismiss()
+            return true
+        }
+        if commandSelector == #selector(moveUp(_:)) {
+            moveSelection(by: -1)
+            return true
+        }
+        if commandSelector == #selector(moveDown(_:)) {
+            moveSelection(by: 1)
+            return true
+        }
+        return false
+    }
+
+    // MARK: - NSTableViewDataSource
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        filteredItems.count
+    }
+
+    // MARK: - NSTableViewDelegate
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let identifier = NSUserInterfaceItemIdentifier("ClipCell")
+        let cellView: NSTableCellView
+
+        // セルの再利用（NSTableView の標準パターン）
+        if let existing = tableView.makeView(withIdentifier: identifier, owner: nil) as? NSTableCellView {
+            cellView = existing
+        } else {
+            let view = NSTableCellView()
+            view.identifier = identifier
+            let tf = NSTextField(labelWithString: "")
+            tf.lineBreakMode = .byTruncatingTail
+            tf.font = .systemFont(ofSize: Layout.cellFontSize)
+            tf.backgroundColor = .clear
+            tf.drawsBackground = false
+            tf.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(tf)
+            view.textField = tf
+            NSLayoutConstraint.activate([
+                tf.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Layout.cellPadding),
+                tf.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Layout.cellPadding),
+                tf.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            ])
+            cellView = view
+        }
+
+        // 改行を半角スペースに置換して1行表示
+        let item = filteredItems[row]
+        cellView.textField?.stringValue = item.text
+            .components(separatedBy: .newlines)
+            .joined(separator: " ")
+        return cellView
+    }
+
+    // MARK: - Actions
+
+    @objc private func tableDoubleClicked() {
+        selectCurrentItem()
+    }
+
+    /// テーブルで選択中のアイテムのテキストを返す。未選択なら nil。
+    private func selectedText() -> String? {
+        let row = tableView.selectedRow
+        guard row >= 0, row < filteredItems.count else { return nil }
+        return filteredItems[row].text
+    }
+
+    /// Enter / ダブルクリック: 選択アイテムをペースト
+    private func selectCurrentItem() {
+        guard let text = selectedText() else { return }
+        let app = previousApp
+        // dismiss() 内の previousApp?.activate() で二重に activate されるのを防ぐ
+        previousApp = nil
+        dismiss()
+        onPaste?(text, app)
+    }
+
+    /// Cmd+C: 選択アイテムをクリップボードにコピー（ペーストはしない）
+    private func copyCurrentItem() {
+        guard let text = selectedText() else { return }
+        dismiss()
+        onCopy?(text)
+    }
+
+    private func moveSelection(by delta: Int) {
+        guard !filteredItems.isEmpty else { return }
+        var newRow = tableView.selectedRow + delta
+        newRow = max(0, min(newRow, filteredItems.count - 1))
+        tableView.selectRowIndexes(IndexSet(integer: newRow), byExtendingSelection: false)
+        tableView.scrollRowToVisible(newRow)
+    }
+}
+
+// MARK: - Comparable+Clamped
+
+private extension Comparable {
+    /// 値を指定範囲内にクランプする。positionNearCursor() で画面端の制限に使用。
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/Sources/FuzzyPaste/main.swift
+++ b/Sources/FuzzyPaste/main.swift
@@ -1,0 +1,13 @@
+import AppKit
+
+let app = NSApplication.shared
+
+// .accessory にすることで Dock にアイコンを表示せず、メニューバー専用アプリとして動作する。
+// Info.plist の LSUIElement=true と合わせて、メニューバー常駐アプリを実現。
+app.setActivationPolicy(.accessory)
+
+let delegate = AppDelegate()
+app.delegate = delegate
+
+// AppKit のイベントループを開始。ここでアプリが起動し、終了するまで戻らない。
+app.run()


### PR DESCRIPTION
## Summary
- macOS メニューバー常駐型クリップボードマネージャーの初期実装
- fuzzy search による履歴検索、グローバルホットキー (Cmd+Shift+V)、元アプリへの自動ペースト
- フロストガラス風UI、カーソル位置基準のウィンドウ表示、ヒントバー

## 主な構成
| ファイル | 役割 |
|---------|------|
| `main.swift` | エントリーポイント、メニューバーアプリ設定 |
| `AppDelegate.swift` | 全体統括（監視・ホットキー・ウィンドウ管理） |
| `ClipboardMonitor.swift` | NSPasteboard ポーリング (0.5秒間隔) |
| `HistoryStore.swift` | JSON 永続化、最大500件、重複排除 |
| `FuzzyMatcher.swift` | 連続一致ボーナス付き fuzzy search |
| `HotkeyManager.swift` | Carbon API による Cmd+Shift+V |
| `SearchWindow.swift` | NSPanel + NSVisualEffectView フローティングUI |
| `PasteHelper.swift` | CGEvent による Cmd+V シミュレート |