### PR TITLE
fix: 検索ウィンドウ・プレビューのポップアップ演出を改善

### DIFF
--- a/Sources/FuzzyPaste/QuickLookPanel.swift
+++ b/Sources/FuzzyPaste/QuickLookPanel.swift
@@ -21,6 +21,11 @@ final class QuickLookPanel: NSPanel {
         static let arrowHeight: CGFloat = 20
         static let cornerRadius: CGFloat = 12
         static let gap: CGFloat = 4
+        // ポップアップアニメーション
+        static let showDuration: CFTimeInterval = 0.18
+        static let dismissDuration: CFTimeInterval = 0.12
+        static let showScale: CGFloat = 0.85
+        static let dismissScale: CGFloat = 0.88
     }
 
     private let visualEffect = NSVisualEffectView()
@@ -261,18 +266,26 @@ final class QuickLookPanel: NSPanel {
             alphaValue = 0
             orderFront(nil)
 
+            // 矢印位置を起点にスケールアニメーション
+            if let layer = contentView?.layer {
+                let origin = arrowOriginInLayer(layer)
+                let fromTransform = Self.scaleTransform(around: origin, scale: Layout.showScale)
+
+                layer.transform = fromTransform
+                let anim = CABasicAnimation(keyPath: "transform")
+                anim.fromValue = fromTransform
+                anim.toValue = CATransform3DIdentity
+                anim.duration = Layout.showDuration
+                anim.timingFunction = CAMediaTimingFunction(name: .easeOut)
+                anim.isRemovedOnCompletion = true
+                layer.transform = CATransform3DIdentity
+                layer.add(anim, forKey: "popup")
+            }
+
             NSAnimationContext.runAnimationGroup { ctx in
-                ctx.duration = 0.18
+                ctx.duration = Layout.showDuration
                 ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
                 self.animator().alphaValue = 1
-            }
-            if let layer = contentView?.layer {
-                let anim = CABasicAnimation(keyPath: "transform.scale")
-                anim.fromValue = 0.92
-                anim.toValue = 1.0
-                anim.duration = 0.18
-                anim.timingFunction = CAMediaTimingFunction(name: .easeOut)
-                layer.add(anim, forKey: "popup")
             }
         } else {
             alphaValue = 1
@@ -294,11 +307,15 @@ final class QuickLookPanel: NSPanel {
 
     /// ポップアウトアニメーション付きで閉じる。
     func dismissAnimated() {
+        // 矢印位置を起点にスケールダウン
         if let layer = contentView?.layer {
-            let anim = CABasicAnimation(keyPath: "transform.scale")
-            anim.fromValue = 1.0
-            anim.toValue = 0.92
-            anim.duration = 0.12
+            let origin = arrowOriginInLayer(layer)
+            let toTransform = Self.scaleTransform(around: origin, scale: Layout.dismissScale)
+
+            let anim = CABasicAnimation(keyPath: "transform")
+            anim.fromValue = CATransform3DIdentity
+            anim.toValue = toTransform
+            anim.duration = Layout.dismissDuration
             anim.timingFunction = CAMediaTimingFunction(name: .easeIn)
             anim.fillMode = .forwards
             anim.isRemovedOnCompletion = false
@@ -306,14 +323,35 @@ final class QuickLookPanel: NSPanel {
         }
 
         NSAnimationContext.runAnimationGroup({ ctx in
-            ctx.duration = 0.12
+            ctx.duration = Layout.dismissDuration
             ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
             self.animator().alphaValue = 0
         }, completionHandler: {
             self.orderOut(nil)
             self.alphaValue = 1
             self.contentView?.layer?.removeAllAnimations()
+            self.contentView?.layer?.transform = CATransform3DIdentity
         })
+    }
+
+    /// 矢印の位置をレイヤー座標系での起点として返す。
+    private func arrowOriginInLayer(_ layer: CALayer) -> CGPoint {
+        let bounds = layer.bounds
+        // 矢印側を起点にする: 左に矢印があれば x=0、右なら x=bounds.width
+        let x: CGFloat = arrowOnLeft ? 0 : bounds.width
+        // arrowCenterY はパネル内での矢印の Y 位置（下原点）
+        let y = arrowCenterY
+        return CGPoint(x: x, y: y)
+    }
+
+    /// 指定した起点を中心にスケールする CATransform3D を生成。
+    /// Note: SearchWindow にも同一の実装あり（ファイル間依存を避けるため各クラスに配置）。
+    private static func scaleTransform(around origin: CGPoint, scale: CGFloat) -> CATransform3D {
+        var t = CATransform3DIdentity
+        t = CATransform3DTranslate(t, origin.x, origin.y, 0)
+        t = CATransform3DScale(t, scale, scale, 1)
+        t = CATransform3DTranslate(t, -origin.x, -origin.y, 0)
+        return t
     }
 
     // MARK: - Layout calculation

--- a/Sources/FuzzyPaste/SearchWindow.swift
+++ b/Sources/FuzzyPaste/SearchWindow.swift
@@ -139,8 +139,8 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
     private enum Anim {
         static let showDuration: CFTimeInterval = 0.15
         static let dismissDuration: CFTimeInterval = 0.1
-        static let showScale: CGFloat = 0.96
-        static let dismissScale: CGFloat = 0.98
+        static let showScale: CGFloat = 0.90
+        static let dismissScale: CGFloat = 0.95
     }
 
     /// レイアウト定数。プリセットにより値が変わる。
@@ -540,26 +540,33 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
 
         // アニメーション初期状態
         alphaValue = 0
-        contentView?.layer?.setAffineTransform(CGAffineTransform(scaleX: Anim.showScale, y: Anim.showScale))
 
         makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
         makeFirstResponder(searchField)
 
-        // フェードイン + スケールアニメーション
+        // カーソル位置を起点にスケールアニメーション
+        if let layer = contentView?.layer {
+            let origin = cursorOriginInLayer(layer)
+            let fromTransform = Self.scaleTransform(around: origin, scale: Anim.showScale)
+
+            layer.transform = fromTransform
+            let anim = CABasicAnimation(keyPath: "transform")
+            anim.fromValue = fromTransform
+            anim.toValue = CATransform3DIdentity
+            anim.duration = Anim.showDuration
+            anim.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            anim.isRemovedOnCompletion = true
+            layer.transform = CATransform3DIdentity
+            layer.add(anim, forKey: "showScale")
+        }
+
+        // フェードイン
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = Anim.showDuration
             ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
             self.animator().alphaValue = 1
         }
-        let scaleAnim = CABasicAnimation(keyPath: "transform.scale")
-        scaleAnim.fromValue = Anim.showScale
-        scaleAnim.toValue = 1.0
-        scaleAnim.duration = Anim.showDuration
-        scaleAnim.timingFunction = CAMediaTimingFunction(name: .easeOut)
-        scaleAnim.isRemovedOnCompletion = true
-        contentView?.layer?.setAffineTransform(.identity)
-        contentView?.layer?.add(scaleAnim, forKey: "showScale")
 
         // 先頭のアイテムを自動選択
         if !filteredItems.isEmpty {
@@ -575,15 +582,20 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
         let app = previousApp
         previousApp = nil
 
-        // スケールダウン + フェードアウト
-        let scaleAnim = CABasicAnimation(keyPath: "transform.scale")
-        scaleAnim.fromValue = 1.0
-        scaleAnim.toValue = Anim.dismissScale
-        scaleAnim.duration = Anim.dismissDuration
-        scaleAnim.timingFunction = CAMediaTimingFunction(name: .easeIn)
-        scaleAnim.fillMode = .forwards
-        scaleAnim.isRemovedOnCompletion = false
-        contentView?.layer?.add(scaleAnim, forKey: "dismissScale")
+        // カーソル位置を起点にスケールダウン + フェードアウト
+        if let layer = contentView?.layer {
+            let origin = cursorOriginInLayer(layer)
+            let toTransform = Self.scaleTransform(around: origin, scale: Anim.dismissScale)
+
+            let scaleAnim = CABasicAnimation(keyPath: "transform")
+            scaleAnim.fromValue = CATransform3DIdentity
+            scaleAnim.toValue = toTransform
+            scaleAnim.duration = Anim.dismissDuration
+            scaleAnim.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            scaleAnim.fillMode = .forwards
+            scaleAnim.isRemovedOnCompletion = false
+            layer.add(scaleAnim, forKey: "dismissScale")
+        }
 
         NSAnimationContext.runAnimationGroup({ ctx in
             ctx.duration = Anim.dismissDuration
@@ -593,7 +605,7 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
             self?.contentView?.layer?.removeAnimation(forKey: "dismissScale")
             self?.orderOut(nil)
             self?.alphaValue = 1
-            self?.contentView?.layer?.setAffineTransform(.identity)
+            self?.contentView?.layer?.transform = CATransform3DIdentity
             self?.isDismissing = false
             app?.activate()
         })
@@ -617,6 +629,30 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
         y = (y - windowSize.height).clamped(to: screenFrame.minY...(screenFrame.maxY - windowSize.height))
 
         setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    /// カーソル位置をレイヤー座標系での起点として返す。
+    private func cursorOriginInLayer(_ layer: CALayer) -> CGPoint {
+        let mouseLocation = NSEvent.mouseLocation
+        let windowFrame = frame
+        let bounds = layer.bounds
+
+        // カーソル位置をレイヤー内の座標に変換
+        let relX = ((mouseLocation.x - windowFrame.minX) / windowFrame.width).clamped(to: 0...1)
+        let relY = ((mouseLocation.y - windowFrame.minY) / windowFrame.height).clamped(to: 0...1)
+
+        return CGPoint(x: relX * bounds.width, y: relY * bounds.height)
+    }
+
+    /// 指定した起点を中心にスケールする CATransform3D を生成。
+    /// translate → scale → translate で anchorPoint を変えずに実現。
+    /// Note: QuickLookPanel にも同一の実装あり（ファイル間依存を避けるため各クラスに配置）。
+    private static func scaleTransform(around origin: CGPoint, scale: CGFloat) -> CATransform3D {
+        var t = CATransform3DIdentity
+        t = CATransform3DTranslate(t, origin.x, origin.y, 0)
+        t = CATransform3DScale(t, scale, scale, 1)
+        t = CATransform3DTranslate(t, -origin.x, -origin.y, 0)
+        return t
     }
 
     // MARK: - Window lifecycle


### PR DESCRIPTION
## Summary
- 検索ウィンドウ: カーソル位置を起点にスケールアニメーション（0.90→1.0）で、カーソルから展開する演出に改善
- Quick Look プレビュー: 矢印位置を起点にスケールアニメーション（0.85→1.0）で、選択行から展開する演出に改善
- `CATransform3D` の translate→scale→translate パターンで `anchorPoint` を変更せず起点指定を実現（AppKit のレイヤー管理との衝突を回避）
- アニメーション定数を `Layout` / `Anim` enum に定数化

Closes #27

## Test plan
- [ ] ホットキーで検索ウィンドウを表示 → カーソル位置から展開するか確認
- [ ] 検索ウィンドウを閉じる → カーソル方向に縮むか確認
- [ ] Shift+Space で Quick Look プレビューを表示 → 矢印（選択行）から展開するか確認
- [ ] プレビューを閉じる → 矢印方向に縮むか確認
- [ ] 起動後の初回表示でも正しく動作するか確認
- [ ] 画面端でも正しく動作するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)