### PR TITLE
fix: スニペット Import/Export で画像/ファイルの実体データを含める

### DIFF
--- a/Sources/FuzzyPaste/FileStore.swift
+++ b/Sources/FuzzyPaste/FileStore.swift
@@ -52,6 +52,20 @@ final class FileStore {
         filesDir.appendingPathComponent(fileName)
     }
 
+    /// 外部ファイルを新しい UUID ファイル名でインポートする。
+    /// 成功時は新しいファイル名を返す。
+    func importFile(from sourceURL: URL, fileExtension ext: String) -> String? {
+        guard let data = try? Data(contentsOf: sourceURL) else { return nil }
+        let newFileName = ext.isEmpty ? UUID().uuidString : "\(UUID().uuidString).\(ext)"
+        let destURL = filesDir.appendingPathComponent(newFileName)
+        do {
+            try data.write(to: destURL, options: .atomic)
+        } catch {
+            return nil
+        }
+        return newFileName
+    }
+
     /// ファイルタイプに対応するアイコンを返す。拡張子単位でキャッシュ。
     func icon(for metadata: FileMetadata) -> NSImage {
         let key = metadata.fileExtension as NSString

--- a/Sources/FuzzyPaste/ImageStore.swift
+++ b/Sources/FuzzyPaste/ImageStore.swift
@@ -72,6 +72,21 @@ final class ImageStore {
         imagesDir.appendingPathComponent(fileName)
     }
 
+    /// 外部ファイルを新しい UUID ファイル名でインポートし、サムネイルも生成する。
+    /// 成功時は新しいファイル名を返す。
+    func importImage(from sourceURL: URL) -> String? {
+        guard let data = try? Data(contentsOf: sourceURL) else { return nil }
+        let newFileName = "\(UUID().uuidString).png"
+        let destURL = imagesDir.appendingPathComponent(newFileName)
+        do {
+            try data.write(to: destURL, options: .atomic)
+        } catch {
+            return nil
+        }
+        generateThumbnail(fileName: newFileName, sourceData: data)
+        return newFileName
+    }
+
     /// 画像ファイルとサムネイルを削除する。
     func delete(fileName: String) {
         let fileURL = imagesDir.appendingPathComponent(fileName)

--- a/Sources/FuzzyPaste/SnippetManagerWindow.swift
+++ b/Sources/FuzzyPaste/SnippetManagerWindow.swift
@@ -1382,16 +1382,51 @@ final class SnippetManagerWindow: NSWindow, NSTableViewDataSource, NSTableViewDe
 
     @objc private func importClicked() {
         let openPanel = NSOpenPanel()
-        openPanel.allowedContentTypes = [.json]
+        openPanel.allowedContentTypes = [.json, .zip]
         openPanel.canChooseFiles = true
         openPanel.canChooseDirectories = false
         openPanel.allowsMultipleSelection = false
-        openPanel.message = "インポートする JSON ファイルを選択してください"
+        openPanel.message = "インポートするファイルを選択してください（.zip または .json）"
 
         guard openPanel.runModal() == .OK, let url = openPanel.url else { return }
 
         do {
-            let result = try store.parseImportFile(url: url)
+            let ext = url.pathExtension.lowercased()
+            let isBundle = ext == "zip" || ext == "fuzzypaste"
+
+            // バンドルの場合は展開して snippets.json を取得
+            let jsonData: Data
+            var bundleTempDir: URL?
+
+            if isBundle {
+                let tempDir = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("FuzzyPaste-import-\(UUID().uuidString)")
+                try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+                bundleTempDir = tempDir
+
+                let proc = Process()
+                proc.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+                proc.arguments = ["-x", "-k", url.path, tempDir.path]
+                try proc.run()
+                proc.waitUntilExit()
+                guard proc.terminationStatus == 0 else {
+                    throw NSError(domain: "FuzzyPaste", code: 1,
+                                  userInfo: [NSLocalizedDescriptionKey: "ZIP ファイルの展開に失敗しました"])
+                }
+
+                let jsonURL = tempDir.appendingPathComponent("snippets.json")
+                guard FileManager.default.fileExists(atPath: jsonURL.path) else {
+                    throw NSError(domain: "FuzzyPaste", code: 2,
+                                  userInfo: [NSLocalizedDescriptionKey: "バンドル内に snippets.json が見つかりません"])
+                }
+                jsonData = try Data(contentsOf: jsonURL)
+            } else {
+                jsonData = try Data(contentsOf: url)
+            }
+
+            defer { if let dir = bundleTempDir { try? FileManager.default.removeItem(at: dir) } }
+
+            let result = try store.parseImportData(jsonData)
             let total = result.new.count + result.duplicates.count
 
             let alert = NSAlert()
@@ -1416,7 +1451,36 @@ final class SnippetManagerWindow: NSWindow, NSTableViewDataSource, NSTableViewDe
 
             guard alert.runModal() == .alertFirstButtonReturn else { return }
 
-            store.importItems(result.new)
+            if let tempDir = bundleTempDir {
+                // バンドルから画像・ファイルをインポートし、ファイル名マッピングを作成
+                var fileNameMapping: [String: String] = [:]
+                let bundleImagesDir = tempDir.appendingPathComponent("images")
+                let bundleFilesDir = tempDir.appendingPathComponent("files")
+
+                for item in result.new {
+                    switch item.content {
+                    case .image(let meta):
+                        let sourceURL = bundleImagesDir.appendingPathComponent(meta.fileName)
+                        if FileManager.default.fileExists(atPath: sourceURL.path),
+                           let newName = imageStore.importImage(from: sourceURL) {
+                            fileNameMapping[meta.fileName] = newName
+                        }
+                    case .file(let meta):
+                        let sourceURL = bundleFilesDir.appendingPathComponent(meta.fileName)
+                        if FileManager.default.fileExists(atPath: sourceURL.path),
+                           let newName = fileStore.importFile(from: sourceURL, fileExtension: meta.fileExtension) {
+                            fileNameMapping[meta.fileName] = newName
+                        }
+                    case .text:
+                        break
+                    }
+                }
+
+                store.importItems(result.new, fileNameMapping: fileNameMapping)
+            } else {
+                store.importItems(result.new)
+            }
+
             tableView.reloadData()
             if !store.items.isEmpty {
                 tableView.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
@@ -1443,15 +1507,32 @@ final class SnippetManagerWindow: NSWindow, NSTableViewDataSource, NSTableViewDe
             return
         }
 
+        let hasMediaSnippets = store.items.contains {
+            switch $0.content {
+            case .image, .file: return true
+            case .text: return false
+            }
+        }
+
         let savePanel = NSSavePanel()
-        savePanel.allowedContentTypes = [.json]
-        savePanel.nameFieldStringValue = "snippets.json"
-        savePanel.message = "スニペットのエクスポート先を選択してください"
+        if hasMediaSnippets {
+            savePanel.allowedContentTypes = [.zip]
+            savePanel.nameFieldStringValue = "snippets.zip"
+            savePanel.message = "スニペットをバンドル（ZIP）でエクスポートします"
+        } else {
+            savePanel.allowedContentTypes = [.json]
+            savePanel.nameFieldStringValue = "snippets.json"
+            savePanel.message = "スニペットのエクスポート先を選択してください"
+        }
 
         guard savePanel.runModal() == .OK, let url = savePanel.url else { return }
 
         do {
-            try store.exportToFile(url: url)
+            if hasMediaSnippets {
+                try exportBundle(to: url)
+            } else {
+                try store.exportToFile(url: url)
+            }
         } catch {
             let alert = NSAlert()
             alert.alertStyle = .critical
@@ -1459,6 +1540,53 @@ final class SnippetManagerWindow: NSWindow, NSTableViewDataSource, NSTableViewDe
             alert.informativeText = error.localizedDescription
             alert.addButton(withTitle: "OK")
             alert.runModal()
+        }
+    }
+
+    /// JSON + 画像/ファイルを ZIP バンドルにまとめてエクスポートする。
+    private func exportBundle(to url: URL) throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FuzzyPaste-export-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // snippets.json を書き出し
+        let jsonData = try store.exportData()
+        try jsonData.write(to: tempDir.appendingPathComponent("snippets.json"), options: .atomic)
+
+        // 画像・ファイルの実体をコピー
+        let fm = FileManager.default
+        let bundleImagesDir = tempDir.appendingPathComponent("images")
+        let bundleFilesDir = tempDir.appendingPathComponent("files")
+        try? fm.createDirectory(at: bundleImagesDir, withIntermediateDirectories: true)
+        try? fm.createDirectory(at: bundleFilesDir, withIntermediateDirectories: true)
+
+        for item in store.items {
+            switch item.content {
+            case .image(let meta):
+                let src = imageStore.imageURL(for: meta.fileName)
+                if fm.fileExists(atPath: src.path) {
+                    try fm.copyItem(at: src, to: bundleImagesDir.appendingPathComponent(meta.fileName))
+                }
+            case .file(let meta):
+                let src = fileStore.fileURL(for: meta.fileName)
+                if fm.fileExists(atPath: src.path) {
+                    try fm.copyItem(at: src, to: bundleFilesDir.appendingPathComponent(meta.fileName))
+                }
+            case .text:
+                break
+            }
+        }
+
+        // ditto で ZIP 作成
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+        proc.arguments = ["-c", "-k", "--sequesterRsrc", tempDir.path, url.path]
+        try proc.run()
+        proc.waitUntilExit()
+        guard proc.terminationStatus == 0 else {
+            throw NSError(domain: "FuzzyPaste", code: 3,
+                          userInfo: [NSLocalizedDescriptionKey: "ZIP ファイルの作成に失敗しました"])
         }
     }
 

--- a/Sources/FuzzyPasteCore/SnippetStore.swift
+++ b/Sources/FuzzyPasteCore/SnippetStore.swift
@@ -7,6 +7,30 @@ public enum SnippetContent: Codable, Sendable, Equatable {
     case file(FileMetadata)
 }
 
+extension SnippetContent {
+    /// ファイル名マッピングを適用した新しい SnippetContent を返す。
+    /// テキストの場合はそのまま返す。
+    func remappingFileName(_ mapping: [String: String]) -> SnippetContent {
+        switch self {
+        case .text:
+            return self
+        case .image(let meta):
+            guard let newName = mapping[meta.fileName] else { return self }
+            return .image(ImageMetadata(
+                fileName: newName, originalUTType: meta.originalUTType,
+                originalFileName: meta.originalFileName,
+                pixelWidth: meta.pixelWidth, pixelHeight: meta.pixelHeight,
+                fileSizeBytes: meta.fileSizeBytes))
+        case .file(let meta):
+            guard let newName = mapping[meta.fileName] else { return self }
+            return .file(FileMetadata(
+                fileName: newName, originalFileName: meta.originalFileName,
+                fileExtension: meta.fileExtension, utType: meta.utType,
+                fileSizeBytes: meta.fileSizeBytes))
+        }
+    }
+}
+
 /// スニペットアイテム。title と content で登録し、両方で検索可能。
 public struct SnippetItem: Codable, Identifiable, Sendable {
     public let id: UUID
@@ -173,6 +197,16 @@ public final class SnippetStore {
         }
         items.insert(contentsOf: reassigned, at: 0)
         save()
+    }
+
+    /// ファイル名マッピングを適用してスニペットをインポートする（新しい UUID を割り当て）。
+    /// バンドルインポート時に、古いファイル名を新しいファイル名に置き換える。
+    public func importItems(_ newItems: [SnippetItem], fileNameMapping: [String: String]) {
+        let remapped = newItems.map { item -> SnippetItem in
+            let content = item.content.remappingFileName(fileNameMapping)
+            return SnippetItem(id: item.id, title: item.title, content: content, tags: item.tags, createdAt: item.createdAt)
+        }
+        importItems(remapped)
     }
 
     /// 重複判定用キーを生成する。

--- a/Sources/fpaste/FPaste.swift
+++ b/Sources/fpaste/FPaste.swift
@@ -147,27 +147,58 @@ extension FPaste {
     struct Import: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "import",
-            abstract: "JSON ファイルからスニペットをインポート"
+            abstract: "スニペットをインポート（ZIP バンドルまたは JSON）"
         )
 
-        @Argument(help: "インポートする JSON ファイルのパス（\"-\" で stdin）")
+        @Argument(help: "インポートするファイルのパス（.zip / .json / \"-\" で stdin JSON）")
         var file: String
 
         func run() async throws {
-            // stdin またはファイルから Data を読み込み
-            let data: Data
+            let fm = FileManager.default
+            let isBundle: Bool
+            let jsonData: Data
+            var bundleTempDir: URL?
+
             if file == "-" || file == "/dev/stdin" {
-                data = FileHandle.standardInput.readDataToEndOfFile()
+                isBundle = false
+                jsonData = FileHandle.standardInput.readDataToEndOfFile()
             } else {
                 let url = URL(fileURLWithPath: file)
-                guard FileManager.default.fileExists(atPath: url.path) else {
+                guard fm.fileExists(atPath: url.path) else {
                     throw ValidationError("ファイルが見つかりません: \(file)")
                 }
-                data = try Data(contentsOf: url)
+
+                let ext = url.pathExtension.lowercased()
+                isBundle = ext == "zip" || ext == "fuzzypaste"
+
+                if isBundle {
+                    let tempDir = fm.temporaryDirectory
+                        .appendingPathComponent("FuzzyPaste-import-\(UUID().uuidString)")
+                    try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+                    bundleTempDir = tempDir
+
+                    let proc = Process()
+                    proc.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+                    proc.arguments = ["-x", "-k", url.path, tempDir.path]
+                    try proc.run()
+                    proc.waitUntilExit()
+                    guard proc.terminationStatus == 0 else {
+                        throw ValidationError("ZIP ファイルの展開に失敗しました")
+                    }
+                    let jsonURL = tempDir.appendingPathComponent("snippets.json")
+                    guard fm.fileExists(atPath: jsonURL.path) else {
+                        throw ValidationError("バンドル内に snippets.json が見つかりません")
+                    }
+                    jsonData = try Data(contentsOf: jsonURL)
+                } else {
+                    jsonData = try Data(contentsOf: url)
+                }
             }
 
+            defer { if let dir = bundleTempDir { try? fm.removeItem(at: dir) } }
+
             let store = await SnippetStore()
-            let result = try await store.parseImportData(data)
+            let result = try await store.parseImportData(jsonData)
 
             // プレビュー表示
             print("--- インポートプレビュー ---")
@@ -177,9 +208,52 @@ extension FPaste {
             for item in result.duplicates { print("  = \(item.title)") }
 
             if !result.new.isEmpty {
-                await store.importItems(result.new)
+                if let tempDir = bundleTempDir {
+                    let mapping = copyBundleFiles(from: tempDir, items: result.new)
+                    await store.importItems(result.new, fileNameMapping: mapping)
+                } else {
+                    await store.importItems(result.new)
+                }
                 print("\n\(result.new.count) 件インポートしました。")
             }
+        }
+
+        /// バンドルから画像・ファイルの実体をアプリのデータディレクトリにコピーし、ファイル名マッピングを返す。
+        private func copyBundleFiles(from bundleDir: URL, items: [SnippetItem]) -> [String: String] {
+            let fm = FileManager.default
+            let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            let base = appSupport.appendingPathComponent("FuzzyPaste")
+            let imagesDir = base.appendingPathComponent("images")
+            let filesDir = base.appendingPathComponent("files")
+            try? fm.createDirectory(at: imagesDir, withIntermediateDirectories: true)
+            try? fm.createDirectory(at: filesDir, withIntermediateDirectories: true)
+
+            let bundleImagesDir = bundleDir.appendingPathComponent("images")
+            let bundleFilesDir = bundleDir.appendingPathComponent("files")
+
+            var mapping: [String: String] = [:]
+            for item in items {
+                switch item.content {
+                case .image(let meta):
+                    let src = bundleImagesDir.appendingPathComponent(meta.fileName)
+                    guard fm.fileExists(atPath: src.path) else { continue }
+                    let newName = "\(UUID().uuidString).png"
+                    let dst = imagesDir.appendingPathComponent(newName)
+                    try? fm.copyItem(at: src, to: dst)
+                    mapping[meta.fileName] = newName
+                case .file(let meta):
+                    let src = bundleFilesDir.appendingPathComponent(meta.fileName)
+                    guard fm.fileExists(atPath: src.path) else { continue }
+                    let ext = meta.fileExtension
+                    let newName = ext.isEmpty ? UUID().uuidString : "\(UUID().uuidString).\(ext)"
+                    let dst = filesDir.appendingPathComponent(newName)
+                    try? fm.copyItem(at: src, to: dst)
+                    mapping[meta.fileName] = newName
+                case .text:
+                    break
+                }
+            }
+            return mapping
         }
     }
 }
@@ -188,22 +262,93 @@ extension FPaste {
 
 extension FPaste {
     struct Export: AsyncParsableCommand {
-        static let configuration = CommandConfiguration(abstract: "スニペットを JSON エクスポート")
+        static let configuration = CommandConfiguration(abstract: "スニペットをエクスポート（ZIP バンドルまたは JSON）")
 
-        @Option(name: .shortAndLong, help: "出力ファイルパス（省略時は stdout）")
+        @Option(name: .shortAndLong, help: "出力ファイルパス（省略時は stdout に JSON）")
         var output: String?
 
         func run() async throws {
             let store = await SnippetStore()
-            let data = try await store.exportData()
+            let items = await store.items
 
-            if let output = output {
-                let url = URL(fileURLWithPath: output)
-                try data.write(to: url, options: .atomic)
+            if items.isEmpty {
+                print("エクスポートするスニペットがありません。")
+                return
+            }
+
+            let hasMedia = items.contains {
+                switch $0.content {
+                case .image, .file: return true
+                case .text: return false
+                }
+            }
+
+            if let output = output, hasMedia {
+                try await exportBundle(store: store, items: items, to: URL(fileURLWithPath: output))
                 print("エクスポートしました: \(output)")
             } else {
-                FileHandle.standardOutput.write(data)
-                FileHandle.standardOutput.write(Data("\n".utf8))
+                let data = try await store.exportData()
+                if let output = output {
+                    let url = URL(fileURLWithPath: output)
+                    try data.write(to: url, options: .atomic)
+                    print("エクスポートしました: \(output)")
+                } else {
+                    if hasMedia {
+                        FileHandle.standardError.write(Data("警告: 画像/ファイルスニペットを含みますが、stdout には JSON のみ出力します。\nバンドル形式でエクスポートするには -o output.zip を指定してください。\n".utf8))
+                    }
+                    FileHandle.standardOutput.write(data)
+                    FileHandle.standardOutput.write(Data("\n".utf8))
+                }
+            }
+        }
+
+        private func exportBundle(store: SnippetStore, items: [SnippetItem], to url: URL) async throws {
+            let fm = FileManager.default
+            let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            let base = appSupport.appendingPathComponent("FuzzyPaste")
+            let appImagesDir = base.appendingPathComponent("images")
+            let appFilesDir = base.appendingPathComponent("files")
+
+            let tempDir = fm.temporaryDirectory
+                .appendingPathComponent("FuzzyPaste-export-\(UUID().uuidString)")
+            try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? fm.removeItem(at: tempDir) }
+
+            // snippets.json
+            let jsonData = try await store.exportData()
+            try jsonData.write(to: tempDir.appendingPathComponent("snippets.json"), options: .atomic)
+
+            // 画像・ファイルの実体をコピー
+            let bundleImagesDir = tempDir.appendingPathComponent("images")
+            let bundleFilesDir = tempDir.appendingPathComponent("files")
+            try? fm.createDirectory(at: bundleImagesDir, withIntermediateDirectories: true)
+            try? fm.createDirectory(at: bundleFilesDir, withIntermediateDirectories: true)
+
+            for item in items {
+                switch item.content {
+                case .image(let meta):
+                    let src = appImagesDir.appendingPathComponent(meta.fileName)
+                    if fm.fileExists(atPath: src.path) {
+                        try fm.copyItem(at: src, to: bundleImagesDir.appendingPathComponent(meta.fileName))
+                    }
+                case .file(let meta):
+                    let src = appFilesDir.appendingPathComponent(meta.fileName)
+                    if fm.fileExists(atPath: src.path) {
+                        try fm.copyItem(at: src, to: bundleFilesDir.appendingPathComponent(meta.fileName))
+                    }
+                case .text:
+                    break
+                }
+            }
+
+            // ditto で ZIP 作成
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+            proc.arguments = ["-c", "-k", "--sequesterRsrc", tempDir.path, url.path]
+            try proc.run()
+            proc.waitUntilExit()
+            guard proc.terminationStatus == 0 else {
+                throw ValidationError("ZIP ファイルの作成に失敗しました")
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #25

- エクスポート時に JSON + 画像/ファイルの実体を ZIP バンドルにまとめて出力
- インポート時に ZIP バンドルから実体ファイルを展開・コピーし、UUID ファイル名を再割当
- テキストのみの場合は従来通り JSON 形式（後方互換）
- GUI (SnippetManagerWindow) と CLI (fpaste) の両方で対応

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `ImageStore.swift` | `importImage(from:)` メソッド追加 |
| `FileStore.swift` | `importFile(from:fileExtension:)` メソッド追加 |
| `SnippetStore.swift` | `importItems(_:fileNameMapping:)` と `SnippetContent.remappingFileName` 追加 |
| `SnippetManagerWindow.swift` | エクスポート→ZIP / インポート→ZIP+JSON両対応 |
| `fpaste.swift` | CLI でも ZIP バンドルのインポート/エクスポートに対応 |

## Test plan

- [ ] テキストのみのスニペットをエクスポート → `.json` で保存されること
- [ ] 画像/ファイルを含むスニペットをエクスポート → `.zip` で保存されること
- [ ] ZIP をインポート → 画像/ファイルが正しく表示・ペーストできること
- [ ] JSON をインポート → 従来通り動作すること（後方互換）
- [ ] 重複スニペットがスキップされること
- [ ] CLI `fpaste export -o out.zip` / `fpaste import out.zip` が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)