### PR TITLE
improve: 検索ウィンドウUI改善・CLI拡張・ファイル変更監視

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DIR = .build/release
 APP_BUNDLE = $(APP_NAME).app
 DEV_FLAGS = -Xswiftc -DDEV
 
-.PHONY: run relaunch relaunch_release hard_reset clean
+.PHONY: run relaunch relaunch_release hard_reset clean seed
 
 define make_bundle
 	rm -rf $(APP_BUNDLE)
@@ -35,6 +35,10 @@ hard_reset:
 	tccutil reset Accessibility $(BUNDLE_ID)
 	rm -rf ~/Library/Application\ Support/FuzzyPaste-Dev
 	@echo "Hard reset complete"
+
+seed:
+	swift build $(DEV_FLAGS)
+	./scripts/seed.sh
 
 clean:
 	swift package clean

--- a/Sources/FuzzyPaste/AppDelegate.swift
+++ b/Sources/FuzzyPaste/AppDelegate.swift
@@ -22,6 +22,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var onboardingWindow: OnboardingWindow?
     private var dynamicSnippetWindow: DynamicSnippetWindow?
     private var cancellables: Set<AnyCancellable> = []
+    private var fileWatchTimer: Timer?
+    private var lastKnownModDates: [String: Date] = [:]
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         setupMenuBar()
@@ -32,6 +34,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         observeWindowSizePreset()
         observeMaxHistoryCount()
         observeHotkeyConfig()
+        startFileWatchers()
     }
 
     // MARK: - ストア初期化
@@ -309,6 +312,41 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func menuShowPreferences() {
         showPreferences()
+    }
+
+    // MARK: - ファイル変更監視
+
+    /// JSON ファイルの変更を定期チェックし、外部プロセス（CLI 等）による変更を自動リロードする。
+    /// ファイルの更新日時を比較し、自分の save 以外の変更のみリロードする。
+    private func startFileWatchers() {
+        fileWatchTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
+            Task { @MainActor [weak self] in
+                self?.checkFileChanges()
+            }
+        }
+    }
+
+    private func checkFileChanges() {
+        let fm = FileManager.default
+        let targets: [(url: URL, lastSave: Date, reload: () -> Void)] = [
+            (historyStore.monitoredFileURL, historyStore.lastSaveDate, { [weak self] in self?.historyStore.reload() }),
+            (snippetStore.monitoredFileURL, snippetStore.lastSaveDate, { [weak self] in self?.snippetStore.reload() }),
+            (preferencesStore.monitoredFileURL, preferencesStore.lastSaveDate, { [weak self] in self?.preferencesStore.reload() }),
+        ]
+
+        for target in targets {
+            let key = target.url.lastPathComponent
+            guard let attrs = try? fm.attributesOfItem(atPath: target.url.path),
+                  let modDate = attrs[.modificationDate] as? Date else { continue }
+            let lastKnown = lastKnownModDates[key] ?? .distantPast
+            if modDate > lastKnown {
+                lastKnownModDates[key] = modDate
+                // 自分の save による変更は無視
+                if Date().timeIntervalSince(target.lastSave) > 1 {
+                    target.reload()
+                }
+            }
+        }
     }
 
     // MARK: - メニューバー

--- a/Sources/FuzzyPaste/PreferencesStore.swift
+++ b/Sources/FuzzyPaste/PreferencesStore.swift
@@ -233,7 +233,8 @@ final class PreferencesStore: ObservableObject {
         save()
     }
 
-    private func load() {
+    /// JSON ファイルから設定を読み込み直す。
+    func reload() {
         guard let data = try? Data(contentsOf: fileURL) else { return }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
@@ -246,11 +247,20 @@ final class PreferencesStore: ObservableObject {
         }
     }
 
+    /// 監視対象の JSON ファイルパスを返す。
+    var monitoredFileURL: URL { fileURL }
+
+    private func load() { reload() }
+
     private func save() {
         let prefs = Preferences(excludedApps: excludedApps, windowSizePreset: windowSizePreset, maxHistoryCount: maxHistoryCount, hotkeyConfig: hotkeyConfig, hasCompletedOnboarding: hasCompletedOnboarding)
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         guard let data = try? encoder.encode(prefs) else { return }
         try? data.write(to: fileURL, options: .atomic)
+        lastSaveDate = Date()
     }
+
+    /// 自分自身の save による変更を無視するためのタイムスタンプ。
+    private(set) var lastSaveDate: Date = .distantPast
 }

--- a/Sources/FuzzyPaste/SearchWindow.swift
+++ b/Sources/FuzzyPaste/SearchWindow.swift
@@ -9,24 +9,29 @@ private final class ModernRowView: NSTableRowView {
     private static let selectionInsetH: CGFloat = 6
     private static let hoverAlpha: CGFloat = 0.07
     private static let selectionAlpha: CGFloat = 0.15
+    private static let separatorInset: CGFloat = 16
 
     var isHovered = false {
         didSet { if oldValue != isHovered { needsDisplay = true } }
     }
 
+    /// 最終行の場合 true。セパレーターを描画しない。
+    var isLastRow = false
+
     override func drawSelection(in dirtyRect: NSRect) {
-        guard isSelected else { return }
-        let insetRect = bounds.insetBy(dx: Self.selectionInsetH, dy: 1)
-        let path = NSBezierPath(roundedRect: insetRect,
-                                xRadius: Self.selectionRadius,
-                                yRadius: Self.selectionRadius)
-        NSColor.controlAccentColor.withAlphaComponent(Self.selectionAlpha).setFill()
-        path.fill()
+        // selectionHighlightStyle = .none のため呼ばれないが念のため空にする
     }
 
     override func drawBackground(in dirtyRect: NSRect) {
         super.drawBackground(in: dirtyRect)
-        if isHovered && !isSelected {
+        if isSelected {
+            let insetRect = bounds.insetBy(dx: Self.selectionInsetH, dy: 1)
+            let path = NSBezierPath(roundedRect: insetRect,
+                                    xRadius: Self.selectionRadius,
+                                    yRadius: Self.selectionRadius)
+            NSColor.controlAccentColor.withAlphaComponent(Self.selectionAlpha).setFill()
+            path.fill()
+        } else if isHovered {
             let insetRect = bounds.insetBy(dx: Self.selectionInsetH, dy: 1)
             let path = NSBezierPath(roundedRect: insetRect,
                                     xRadius: Self.selectionRadius,
@@ -34,7 +39,19 @@ private final class ModernRowView: NSTableRowView {
             NSColor.labelColor.withAlphaComponent(Self.hoverAlpha).setFill()
             path.fill()
         }
+
+        // ピクセル境界にスナップしたセパレーターを描画
+        guard !isLastRow else { return }
+        let scale = window?.backingScaleFactor ?? 2.0
+        let lineHeight = 1.0 / scale
+        let rawY = bounds.maxY - lineHeight
+        let snappedY = round(rawY * scale) / scale
+        NSColor.separatorColor.withAlphaComponent(0.4).setFill()
+        NSRect(x: Self.separatorInset, y: snappedY,
+               width: bounds.width - Self.separatorInset * 2, height: lineHeight).fill()
     }
+
+    override func drawSeparator(in dirtyRect: NSRect) {}
 }
 
 // MARK: - フォーカスを受け取らない NSTableView
@@ -153,7 +170,6 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
     private static let imageCellID = NSUserInterfaceItemIdentifier("ImageClipCell")
     private static let fileCellID = NSUserInterfaceItemIdentifier("FileClipCell")
 
-    private static let timestampTag = 500
     private static let imageTitleTag = 100
     private static let imageSubtitleTag = 101
     private static let fileTitleTag = 300
@@ -340,8 +356,8 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
         tableView.delegate = self
         tableView.rowHeight = layout.rowHeight
         tableView.backgroundColor = .clear
-        tableView.intercellSpacing = NSSize(width: 0, height: 1)
-        tableView.selectionHighlightStyle = .regular
+        tableView.intercellSpacing = NSSize(width: 0, height: 0)
+        tableView.selectionHighlightStyle = .none
         tableView.allowsMultipleSelection = true
         tableView.doubleAction = #selector(tableDoubleClicked)
         tableView.target = self
@@ -932,6 +948,10 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
         } else {
             orderedSelection = []
         }
+        // selectionHighlightStyle = .none では行ビューの再描画が自動で走らないため手動で促す
+        tableView.enumerateAvailableRowViews { rowView, _ in
+            rowView.needsDisplay = true
+        }
         updateSelectionBadges()
         updateHintLabel()
     }
@@ -959,12 +979,15 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
 
     func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
         let id = NSUserInterfaceItemIdentifier("ModernRow")
+        let rowView: ModernRowView
         if let existing = tableView.makeView(withIdentifier: id, owner: nil) as? ModernRowView {
             existing.isHovered = false
-            return existing
+            rowView = existing
+        } else {
+            rowView = ModernRowView()
+            rowView.identifier = id
         }
-        let rowView = ModernRowView()
-        rowView.identifier = id
+        rowView.isLastRow = (row == filteredItems.count - 1)
         return rowView
     }
 
@@ -995,11 +1018,11 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
             case .text(let text):
                 cellView = makeTextCell(tableView: tableView, text: text
                     .components(separatedBy: .newlines)
-                    .joined(separator: " "), date: clipItem.copiedAt)
+                    .joined(separator: " "))
             case .image(let meta):
-                cellView = makeImageCell(tableView: tableView, meta: meta, date: clipItem.copiedAt)
+                cellView = makeImageCell(tableView: tableView, meta: meta)
             case .file(let meta):
-                cellView = makeFileCell(tableView: tableView, meta: meta, date: clipItem.copiedAt)
+                cellView = makeFileCell(tableView: tableView, meta: meta)
             }
         case .snippet(let snippetItem):
             switch snippetItem.content {
@@ -1018,13 +1041,10 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
     // MARK: - Cell factories
 
     /// テキストアイテム用セル
-    private func makeTextCell(tableView: NSTableView, text: String, date: Date) -> NSTableCellView {
+    private func makeTextCell(tableView: NSTableView, text: String) -> NSTableCellView {
         let id = Self.textCellID
         if let existing = tableView.makeView(withIdentifier: id, owner: nil) as? NSTableCellView {
             existing.textField?.stringValue = text
-            if let ts = existing.viewWithTag(Self.timestampTag) as? NSTextField {
-                ts.stringValue = relativeTimeString(from: date)
-            }
             return existing
         }
 
@@ -1040,33 +1060,18 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
         view.addSubview(tf)
         view.textField = tf
 
-        // タイムスタンプ
-        let ts = NSTextField(labelWithString: relativeTimeString(from: date))
-        ts.tag = Self.timestampTag
-        ts.font = .systemFont(ofSize: layout.cellFontSize - 2)
-        ts.textColor = .tertiaryLabelColor
-        ts.alignment = .right
-        ts.setContentHuggingPriority(.required, for: .horizontal)
-        ts.setContentCompressionResistancePriority(.required, for: .horizontal)
-        ts.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(ts)
-
         NSLayoutConstraint.activate([
             tf.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: layout.cellPadding),
-            tf.trailingAnchor.constraint(equalTo: ts.leadingAnchor, constant: -8),
+            tf.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -layout.cellPadding),
             tf.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-
-            ts.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -layout.cellPadding),
-            ts.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            ts.widthAnchor.constraint(greaterThanOrEqualToConstant: 20),
         ])
         return view
     }
 
     /// 画像アイテム用セル（2行レイアウト）:
-    /// [thumb]  filename.png       5m ← 上段: 太字ファイル名 + タイムスタンプ
-    ///          1920×1080  2.3 MB     ← 下段: メタデータ
-    private func makeImageCell(tableView: NSTableView, meta: ImageMetadata, date: Date) -> NSView {
+    /// filename.png              [thumb] ← 上段: 太字ファイル名、右端にサムネ
+    /// 1920×1080  2.3 MB                 ← 下段: メタデータ
+    private func makeImageCell(tableView: NSTableView, meta: ImageMetadata) -> NSView {
         let id = Self.imageCellID
         let titleTag = Self.imageTitleTag
         let subtitleTag = Self.imageSubtitleTag
@@ -1074,18 +1079,15 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
         let thumbView: NSImageView
         let titleLabel: NSTextField
         let subtitleLabel: NSTextField
-        let timeLabel: NSTextField
         let cellView: NSTableCellView
 
         if let existing = tableView.makeView(withIdentifier: id, owner: nil) as? NSTableCellView,
            let existingThumb = existing.imageView,
            let existingTitle = existing.viewWithTag(titleTag) as? NSTextField,
-           let existingSub = existing.viewWithTag(subtitleTag) as? NSTextField,
-           let existingTime = existing.viewWithTag(Self.timestampTag) as? NSTextField {
+           let existingSub = existing.viewWithTag(subtitleTag) as? NSTextField {
             thumbView = existingThumb
             titleLabel = existingTitle
             subtitleLabel = existingSub
-            timeLabel = existingTime
             cellView = existing
         } else {
             cellView = NSTableCellView()
@@ -1109,16 +1111,6 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
             titleLabel.translatesAutoresizingMaskIntoConstraints = false
             cellView.addSubview(titleLabel)
 
-            timeLabel = NSTextField(labelWithString: "")
-            timeLabel.tag = Self.timestampTag
-            timeLabel.font = .systemFont(ofSize: layout.cellFontSize - 2)
-            timeLabel.textColor = .tertiaryLabelColor
-            timeLabel.alignment = .right
-            timeLabel.setContentHuggingPriority(.required, for: .horizontal)
-            timeLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
-            timeLabel.translatesAutoresizingMaskIntoConstraints = false
-            cellView.addSubview(timeLabel)
-
             subtitleLabel = NSTextField(labelWithString: "")
             subtitleLabel.tag = subtitleTag
             subtitleLabel.lineBreakMode = .byTruncatingTail
@@ -1129,38 +1121,27 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
             subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
             cellView.addSubview(subtitleLabel)
 
-            let textLeading = thumbView.trailingAnchor.anchorWithOffset(to: titleLabel.leadingAnchor)
             NSLayoutConstraint.activate([
-                thumbView.leadingAnchor.constraint(equalTo: cellView.leadingAnchor, constant: layout.cellPadding),
+                // サムネを右端に配置
+                thumbView.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -layout.cellPadding),
                 thumbView.centerYAnchor.constraint(equalTo: cellView.centerYAnchor),
                 thumbView.widthAnchor.constraint(equalToConstant: layout.thumbSize),
                 thumbView.heightAnchor.constraint(equalToConstant: layout.thumbSize),
 
-                textLeading.constraint(equalToConstant: 8),
-                titleLabel.trailingAnchor.constraint(equalTo: timeLabel.leadingAnchor, constant: -8),
+                titleLabel.leadingAnchor.constraint(equalTo: cellView.leadingAnchor, constant: layout.cellPadding),
+                titleLabel.trailingAnchor.constraint(equalTo: thumbView.leadingAnchor, constant: -8),
                 titleLabel.bottomAnchor.constraint(equalTo: cellView.centerYAnchor, constant: -1),
 
-                timeLabel.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -layout.cellPadding),
-                timeLabel.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
-                timeLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 20),
-
                 subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
-                subtitleLabel.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -layout.cellPadding),
+                subtitleLabel.trailingAnchor.constraint(equalTo: thumbView.leadingAnchor, constant: -8),
                 subtitleLabel.topAnchor.constraint(equalTo: cellView.centerYAnchor, constant: 1),
             ])
         }
 
-        // サムネイル設定
         thumbView.isHidden = false
         thumbView.image = imageStore?.thumbnail(for: meta.fileName)
-
-        // 上段: ファイル名（なければ空文字）
         titleLabel.stringValue = meta.originalFileName ?? ""
 
-        // タイムスタンプ
-        timeLabel.stringValue = relativeTimeString(from: date)
-
-        // 下段: メタデータ
         let sizeStr = formatFileSize(meta.fileSizeBytes)
         subtitleLabel.stringValue = "\(meta.pixelWidth)×\(meta.pixelHeight)  \(sizeStr)"
 
@@ -1168,9 +1149,9 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
     }
 
     /// ファイルアイテム用セル（2行レイアウト）:
-    /// [icon]  filename.pdf       5m <- 上段: 太字ファイル名 + タイムスタンプ
-    ///         pdf  1.2 MB           <- 下段: 拡張子 + サイズ
-    private func makeFileCell(tableView: NSTableView, meta: FileMetadata, date: Date) -> NSView {
+    /// filename.pdf              [icon] ← 上段: 太字ファイル名、右端にアイコン
+    /// PDF  1.2 MB                      ← 下段: 拡張子 + サイズ
+    private func makeFileCell(tableView: NSTableView, meta: FileMetadata) -> NSView {
         let id = Self.fileCellID
         let titleTag = Self.fileTitleTag
         let subtitleTag = Self.fileSubtitleTag
@@ -1178,18 +1159,15 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
         let iconView: NSImageView
         let titleLabel: NSTextField
         let subtitleLabel: NSTextField
-        let timeLabel: NSTextField
         let cellView: NSTableCellView
 
         if let existing = tableView.makeView(withIdentifier: id, owner: nil) as? NSTableCellView,
            let existingIcon = existing.imageView,
            let existingTitle = existing.viewWithTag(titleTag) as? NSTextField,
-           let existingSub = existing.viewWithTag(subtitleTag) as? NSTextField,
-           let existingTime = existing.viewWithTag(Self.timestampTag) as? NSTextField {
+           let existingSub = existing.viewWithTag(subtitleTag) as? NSTextField {
             iconView = existingIcon
             titleLabel = existingTitle
             subtitleLabel = existingSub
-            timeLabel = existingTime
             cellView = existing
         } else {
             cellView = NSTableCellView()
@@ -1210,16 +1188,6 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
             titleLabel.translatesAutoresizingMaskIntoConstraints = false
             cellView.addSubview(titleLabel)
 
-            timeLabel = NSTextField(labelWithString: "")
-            timeLabel.tag = Self.timestampTag
-            timeLabel.font = .systemFont(ofSize: layout.cellFontSize - 2)
-            timeLabel.textColor = .tertiaryLabelColor
-            timeLabel.alignment = .right
-            timeLabel.setContentHuggingPriority(.required, for: .horizontal)
-            timeLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
-            timeLabel.translatesAutoresizingMaskIntoConstraints = false
-            cellView.addSubview(timeLabel)
-
             subtitleLabel = NSTextField(labelWithString: "")
             subtitleLabel.tag = subtitleTag
             subtitleLabel.lineBreakMode = .byTruncatingTail
@@ -1230,38 +1198,28 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
             subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
             cellView.addSubview(subtitleLabel)
 
-            let textLeading = iconView.trailingAnchor.anchorWithOffset(to: titleLabel.leadingAnchor)
+            let iconSize = layout.thumbSize * 0.5
             NSLayoutConstraint.activate([
-                iconView.leadingAnchor.constraint(equalTo: cellView.leadingAnchor, constant: layout.cellPadding),
+                // アイコンを右端に配置
+                iconView.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -layout.cellPadding),
                 iconView.centerYAnchor.constraint(equalTo: cellView.centerYAnchor),
-                iconView.widthAnchor.constraint(equalToConstant: layout.thumbSize * 0.5),
-                iconView.heightAnchor.constraint(equalToConstant: layout.thumbSize * 0.5),
+                iconView.widthAnchor.constraint(equalToConstant: iconSize),
+                iconView.heightAnchor.constraint(equalToConstant: iconSize),
 
-                textLeading.constraint(equalToConstant: 8),
-                titleLabel.trailingAnchor.constraint(equalTo: timeLabel.leadingAnchor, constant: -8),
+                titleLabel.leadingAnchor.constraint(equalTo: cellView.leadingAnchor, constant: layout.cellPadding),
+                titleLabel.trailingAnchor.constraint(equalTo: iconView.leadingAnchor, constant: -8),
                 titleLabel.bottomAnchor.constraint(equalTo: cellView.centerYAnchor, constant: -1),
 
-                timeLabel.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -layout.cellPadding),
-                timeLabel.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
-                timeLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 20),
-
                 subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
-                subtitleLabel.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -layout.cellPadding),
+                subtitleLabel.trailingAnchor.constraint(equalTo: iconView.leadingAnchor, constant: -8),
                 subtitleLabel.topAnchor.constraint(equalTo: cellView.centerYAnchor, constant: 1),
             ])
         }
 
-        // アイコン設定
         iconView.isHidden = false
         iconView.image = fileStore?.icon(for: meta)
-
-        // 上段: ファイル名
         titleLabel.stringValue = meta.originalFileName
 
-        // タイムスタンプ
-        timeLabel.stringValue = relativeTimeString(from: date)
-
-        // 下段: 拡張子 + サイズ
         let sizeStr = formatFileSize(meta.fileSizeBytes)
         if meta.fileExtension.isEmpty {
             subtitleLabel.stringValue = sizeStr
@@ -1274,7 +1232,7 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
 
     /// スニペット画像セル: makeImageCell を再利用し、タイトルをスニペット名に差し替え
     private func makeSnippetImageCell(tableView: NSTableView, snippet: SnippetItem, meta: ImageMetadata) -> NSView {
-        let cell = makeImageCell(tableView: tableView, meta: meta, date: snippet.createdAt)
+        let cell = makeImageCell(tableView: tableView, meta: meta)
         if let titleLabel = cell.viewWithTag(Self.imageTitleTag) as? NSTextField {
             titleLabel.attributedStringValue = snippetTitleString(snippet)
         }
@@ -1283,7 +1241,7 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
 
     /// スニペットファイルセル: makeFileCell を再利用し、タイトルをスニペット名に差し替え
     private func makeSnippetFileCell(tableView: NSTableView, snippet: SnippetItem, meta: FileMetadata) -> NSView {
-        let cell = makeFileCell(tableView: tableView, meta: meta, date: snippet.createdAt)
+        let cell = makeFileCell(tableView: tableView, meta: meta)
         if let titleLabel = cell.viewWithTag(Self.fileTitleTag) as? NSTextField {
             titleLabel.attributedStringValue = snippetTitleString(snippet)
         }
@@ -1321,16 +1279,13 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
 
         let topLabel: NSTextField
         let bottomLabel: NSTextField
-        let timeLabel: NSTextField
         let cellView: NSView
 
         if let existing = tableView.makeView(withIdentifier: id, owner: nil),
            let existingTop = existing.viewWithTag(topTag) as? NSTextField,
-           let existingBottom = existing.viewWithTag(bottomTag) as? NSTextField,
-           let existingTime = existing.viewWithTag(Self.timestampTag) as? NSTextField {
+           let existingBottom = existing.viewWithTag(bottomTag) as? NSTextField {
             topLabel = existingTop
             bottomLabel = existingBottom
-            timeLabel = existingTime
             cellView = existing
         } else {
             cellView = NSView()
@@ -1343,16 +1298,6 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
             topLabel.drawsBackground = false
             topLabel.translatesAutoresizingMaskIntoConstraints = false
             cellView.addSubview(topLabel)
-
-            timeLabel = NSTextField(labelWithString: "")
-            timeLabel.tag = Self.timestampTag
-            timeLabel.font = .systemFont(ofSize: layout.cellFontSize - 2)
-            timeLabel.textColor = .tertiaryLabelColor
-            timeLabel.alignment = .right
-            timeLabel.setContentHuggingPriority(.required, for: .horizontal)
-            timeLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
-            timeLabel.translatesAutoresizingMaskIntoConstraints = false
-            cellView.addSubview(timeLabel)
 
             bottomLabel = NSTextField(labelWithString: "")
             bottomLabel.tag = bottomTag
@@ -1367,11 +1312,7 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
             NSLayoutConstraint.activate([
                 topLabel.topAnchor.constraint(equalTo: cellView.topAnchor, constant: 8),
                 topLabel.leadingAnchor.constraint(equalTo: cellView.leadingAnchor, constant: layout.cellPadding),
-                topLabel.trailingAnchor.constraint(equalTo: timeLabel.leadingAnchor, constant: -8),
-
-                timeLabel.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -layout.cellPadding),
-                timeLabel.centerYAnchor.constraint(equalTo: topLabel.centerYAnchor),
-                timeLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 20),
+                topLabel.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -layout.cellPadding),
 
                 bottomLabel.topAnchor.constraint(equalTo: topLabel.bottomAnchor, constant: 2),
                 bottomLabel.leadingAnchor.constraint(equalTo: cellView.leadingAnchor, constant: layout.cellPadding + 12),
@@ -1379,11 +1320,7 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
             ])
         }
 
-        // 上段: ★ タイトル + タグバッジ
         topLabel.attributedStringValue = snippetTitleString(snippet)
-
-        // タイムスタンプ
-        timeLabel.stringValue = relativeTimeString(from: snippet.createdAt)
 
         // 下段: 内容プレビュー
         let preview: String
@@ -1767,15 +1704,6 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
             NSLog("FuzzyPaste: dragFileURL copy failed: \(error)")
             return sourceURL
         }
-    }
-
-    /// 相対時間を短い文字列にフォーマット。
-    private func relativeTimeString(from date: Date) -> String {
-        let seconds = max(0, Int(-date.timeIntervalSinceNow))
-        if seconds < 60 { return "now" }
-        if seconds < 3600 { return "\(seconds / 60)m" }
-        if seconds < 86400 { return "\(seconds / 3600)h" }
-        return "\(seconds / 86400)d"
     }
 
     /// ファイルサイズを人間が読みやすい形式にフォーマット。

--- a/Sources/FuzzyPasteCore/HistoryStore.swift
+++ b/Sources/FuzzyPasteCore/HistoryStore.swift
@@ -162,12 +162,19 @@ public final class HistoryStore {
         }
     }
 
-    private func load() {
+    /// JSON ファイルから履歴を読み込み直す。
+    /// 外部プロセス（CLI 等）による変更を反映するために公開している。
+    public func reload() {
         guard let data = try? Data(contentsOf: fileURL) else { return }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         items = (try? decoder.decode([ClipItem].self, from: data)) ?? []
     }
+
+    /// 監視対象の JSON ファイルパスを返す。
+    public var monitoredFileURL: URL { fileURL }
+
+    private func load() { reload() }
 
     /// アトミック書き込みにより、書き込み中にクラッシュしてもファイルが壊れない
     private func save() {
@@ -175,5 +182,9 @@ public final class HistoryStore {
         encoder.dateEncodingStrategy = .iso8601
         guard let data = try? encoder.encode(items) else { return }
         try? data.write(to: fileURL, options: .atomic)
+        lastSaveDate = Date()
     }
+
+    /// 自分自身の save による変更を無視するためのタイムスタンプ。
+    public private(set) var lastSaveDate: Date = .distantPast
 }

--- a/Sources/FuzzyPasteCore/SnippetStore.swift
+++ b/Sources/FuzzyPasteCore/SnippetStore.swift
@@ -219,17 +219,28 @@ public final class SnippetStore {
         }
     }
 
-    private func load() {
+    /// JSON ファイルからスニペットを読み込み直す。
+    /// 外部プロセス（CLI 等）による変更を反映するために公開している。
+    public func reload() {
         guard let data = try? Data(contentsOf: fileURL) else { return }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         items = (try? decoder.decode([SnippetItem].self, from: data)) ?? []
     }
 
+    /// 監視対象の JSON ファイルパスを返す。
+    public var monitoredFileURL: URL { fileURL }
+
+    private func load() { reload() }
+
     private func save() {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         guard let data = try? encoder.encode(items) else { return }
         try? data.write(to: fileURL, options: .atomic)
+        lastSaveDate = Date()
     }
+
+    /// 自分自身の save による変更を無視するためのタイムスタンプ。
+    public private(set) var lastSaveDate: Date = .distantPast
 }

--- a/Sources/fpaste/FPaste.swift
+++ b/Sources/fpaste/FPaste.swift
@@ -1,14 +1,105 @@
+import AppKit
 import ArgumentParser
 import Foundation
 import FuzzyPasteCore
+import ImageIO
+import UniformTypeIdentifiers
 
 @main
 struct FPaste: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "fpaste",
         abstract: "FuzzyPaste CLI — スニペットをターミナルから操作",
-        subcommands: [List.self, Add.self, Remove.self, Search.self, Import.self, Export.self]
+        subcommands: [List.self, Add.self, Remove.self, Search.self, Import.self, Export.self, History.self]
     )
+}
+
+// MARK: - 共通ファイル操作
+
+/// 画像ファイルを images/ に保存し、サムネイルも生成して ImageMetadata を返す。
+private func saveImageFile(path: String) throws -> ImageMetadata {
+    let url = URL(fileURLWithPath: path)
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: url.path) else {
+        throw ValidationError("ファイルが見つかりません: \(path)")
+    }
+
+    let data = try Data(contentsOf: url)
+    let imagesDir = AppPaths.appSupportDir.appendingPathComponent("images")
+    let thumbsDir = imagesDir.appendingPathComponent("thumbs")
+    try? fm.createDirectory(at: imagesDir, withIntermediateDirectories: true)
+    try? fm.createDirectory(at: thumbsDir, withIntermediateDirectories: true)
+
+    guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+          let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+        throw ValidationError("画像ファイルを読み込めません: \(path)")
+    }
+    let rep = NSBitmapImageRep(cgImage: cgImage)
+    guard let pngData = rep.representation(using: .png, properties: [:]) else {
+        throw ValidationError("PNG への変換に失敗しました: \(path)")
+    }
+
+    let fileName = "\(UUID().uuidString).png"
+    try pngData.write(to: imagesDir.appendingPathComponent(fileName), options: .atomic)
+
+    let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]
+    let width = props?[kCGImagePropertyPixelWidth] as? Int ?? cgImage.width
+    let height = props?[kCGImagePropertyPixelHeight] as? Int ?? cgImage.height
+
+    let thumbOpts: [CFString: Any] = [
+        kCGImageSourceCreateThumbnailFromImageAlways: true,
+        kCGImageSourceThumbnailMaxPixelSize: 512,
+        kCGImageSourceCreateThumbnailWithTransform: true,
+    ]
+    if let pngSource = CGImageSourceCreateWithData(pngData as CFData, nil),
+       let cgThumb = CGImageSourceCreateThumbnailAtIndex(pngSource, 0, thumbOpts as CFDictionary) {
+        let thumbRep = NSBitmapImageRep(cgImage: cgThumb)
+        if let thumbData = thumbRep.representation(using: .png, properties: [:]) {
+            try? thumbData.write(to: thumbsDir.appendingPathComponent(fileName), options: .atomic)
+        }
+    }
+
+    return ImageMetadata(
+        fileName: fileName,
+        originalUTType: resolveUTType(for: url),
+        originalFileName: url.lastPathComponent,
+        pixelWidth: width,
+        pixelHeight: height,
+        fileSizeBytes: Int64(pngData.count)
+    )
+}
+
+/// ファイルを files/ にコピーして FileMetadata を返す。
+private func saveGenericFile(path: String) throws -> FileMetadata {
+    let url = URL(fileURLWithPath: path)
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: url.path) else {
+        throw ValidationError("ファイルが見つかりません: \(path)")
+    }
+
+    let data = try Data(contentsOf: url)
+    let filesDir = AppPaths.appSupportDir.appendingPathComponent("files")
+    try? fm.createDirectory(at: filesDir, withIntermediateDirectories: true)
+
+    let ext = url.pathExtension.lowercased()
+    let storedName = ext.isEmpty ? UUID().uuidString : "\(UUID().uuidString).\(ext)"
+    try data.write(to: filesDir.appendingPathComponent(storedName), options: .atomic)
+
+    return FileMetadata(
+        fileName: storedName,
+        originalFileName: url.lastPathComponent,
+        fileExtension: ext,
+        utType: resolveUTType(for: url),
+        fileSizeBytes: Int64(data.count)
+    )
+}
+
+private func resolveUTType(for url: URL) -> String {
+    let ext = url.pathExtension.lowercased()
+    if let type = UTType(filenameExtension: ext) {
+        return type.identifier
+    }
+    return "public.data"
 }
 
 // MARK: - 共通フォーマット
@@ -66,20 +157,59 @@ extension FPaste {
 
 extension FPaste {
     struct Add: AsyncParsableCommand {
-        static let configuration = CommandConfiguration(abstract: "スニペットを追加")
+        static let configuration = CommandConfiguration(
+            abstract: "スニペットを追加（テキスト / 画像 / ファイル）",
+            discussion: """
+            テキスト、画像ファイル、または任意のファイルをスニペットとして登録します。
+            --image / --file を指定しない場合はテキストスニペットとして登録します。
+
+            使用例:
+              fpaste add "挨拶文" "お疲れ様です" --tag メール --tag 定型文
+              fpaste add "ロゴ画像" --image logo.png --tag デザイン
+              fpaste add "設定ファイル" --file config.json --tag 設定
+            """
+        )
 
         @Argument(help: "スニペットのタイトル")
         var title: String
 
-        @Argument(help: "スニペットの内容")
-        var content: String
+        @Argument(help: "スニペットの内容（テキストモード時。--image / --file 指定時は不要）")
+        var content: String?
+
+        @Option(name: .long, help: "画像ファイルのパス（PNG/JPEG 等）")
+        var image: String?
+
+        @Option(name: .long, help: "ファイルのパス（任意の拡張子）")
+        var file: String?
 
         @Option(name: .long, help: "タグ（複数指定可）")
         var tag: [String] = []
 
+        func validate() throws {
+            let modes = [image != nil, file != nil, content != nil].filter { $0 }.count
+            if modes == 0 {
+                throw ValidationError("content, --image, --file のいずれかを指定してください")
+            }
+            if modes > 1 {
+                throw ValidationError("content, --image, --file は同時に指定できません")
+            }
+        }
+
         func run() async throws {
             let store = await SnippetStore()
-            await store.add(title: title, content: .text(content), tags: tag)
+            let snippetContent: SnippetContent
+
+            if let imagePath = image {
+                snippetContent = .image(try saveImageFile(path: imagePath))
+            } else if let filePath = file {
+                snippetContent = .file(try saveGenericFile(path: filePath))
+            } else if let content {
+                snippetContent = .text(content)
+            } else {
+                throw ValidationError("content, --image, --file のいずれかを指定してください")
+            }
+
+            await store.add(title: title, content: snippetContent, tags: tag)
             print("追加しました: \(title)")
         }
     }
@@ -139,6 +269,153 @@ extension FPaste {
             }
         }
     }
+}
+
+// MARK: - history
+
+extension FPaste {
+    struct History: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "クリップボード履歴を操作",
+            discussion: """
+            履歴の一覧表示・追加・全削除を行います。
+            サブコマンドを省略すると一覧を表示します。
+
+            使用例:
+              fpaste history                          # 一覧表示
+              fpaste history list --limit 5           # 最新5件を表示
+              fpaste history add "コピーしたテキスト"
+              fpaste history add --image screenshot.png
+              fpaste history add --file report.pdf
+              fpaste history clear                    # 全件削除
+            """,
+            subcommands: [HistoryList.self, HistoryAdd.self, HistoryClear.self],
+            defaultSubcommand: HistoryList.self
+        )
+    }
+}
+
+extension FPaste.History {
+    struct HistoryList: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "履歴一覧を表示"
+        )
+
+        @Option(name: .shortAndLong, help: "表示件数（省略時は全件）")
+        var limit: Int?
+
+        @Flag(name: .long, help: "JSON 形式で出力")
+        var json = false
+
+        func run() async throws {
+            let store = await HistoryStore()
+            let items = await store.items
+            let displayed = limit.map { Array(items.prefix($0)) } ?? items
+
+            if displayed.isEmpty {
+                print("履歴がありません。")
+                return
+            }
+
+            if json {
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .iso8601
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                let data = try encoder.encode(displayed)
+                print(String(data: data, encoding: .utf8)!)
+            } else {
+                for item in displayed {
+                    print(formatClipItem(item))
+                }
+                if let limit, items.count > limit {
+                    print("... 他 \(items.count - limit) 件")
+                }
+            }
+        }
+    }
+
+    struct HistoryAdd: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "add",
+            abstract: "履歴にアイテムを追加（テキスト / 画像 / ファイル）",
+            discussion: """
+            使用例:
+              fpaste history add "コピーしたテキスト"
+              fpaste history add --image screenshot.png
+              fpaste history add --file report.pdf
+            """
+        )
+
+        @Argument(help: "テキスト内容（--image / --file 指定時は不要）")
+        var text: String?
+
+        @Option(name: .long, help: "画像ファイルのパス（PNG/JPEG 等）")
+        var image: String?
+
+        @Option(name: .long, help: "ファイルのパス（任意の拡張子）")
+        var file: String?
+
+        func validate() throws {
+            let modes = [text != nil, image != nil, file != nil].filter { $0 }.count
+            if modes == 0 {
+                throw ValidationError("text, --image, --file のいずれかを指定してください")
+            }
+            if modes > 1 {
+                throw ValidationError("text, --image, --file は同時に指定できません")
+            }
+        }
+
+        func run() async throws {
+            let store = await HistoryStore()
+
+            if let text {
+                await store.add(text)
+                print("履歴に追加しました（テキスト）")
+            } else if let imagePath = image {
+                let meta = try saveImageFile(path: imagePath)
+                await store.addImage(meta)
+                print("履歴に追加しました（画像: \(meta.pixelWidth)×\(meta.pixelHeight)）")
+            } else if let filePath = file {
+                let meta = try saveGenericFile(path: filePath)
+                await store.addFile(meta)
+                print("履歴に追加しました（ファイル: \(meta.originalFileName)）")
+            }
+        }
+    }
+
+    struct HistoryClear: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "clear",
+            abstract: "履歴を全件削除"
+        )
+
+        func run() async throws {
+            let store = await HistoryStore()
+            let count = await store.items.count
+            if count == 0 {
+                print("履歴は空です。")
+                return
+            }
+            await store.clearAll()
+            print("\(count) 件の履歴を削除しました。")
+        }
+    }
+}
+
+private func formatClipItem(_ item: ClipItem) -> String {
+    let dateStr = ISO8601DateFormatter().string(from: item.copiedAt)
+    let preview: String
+    switch item.content {
+    case .text(let text):
+        preview = String(text.prefix(70)).replacingOccurrences(of: "\n", with: "\\n")
+    case .image(let meta):
+        let name = meta.originalFileName ?? meta.fileName
+        preview = "[画像] \(name) \(meta.pixelWidth)×\(meta.pixelHeight)"
+    case .file(let meta):
+        preview = "[ファイル] \(meta.originalFileName)"
+    }
+    return "\(dateStr)  \(preview)"
 }
 
 // MARK: - import

--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+set -euo pipefail
+
+# FuzzyPaste seed script
+# デバッグ用テストデータをスニペットとクリップボード履歴に投入する。
+# べき等: 同じタイトル/テキストが既に存在する場合はスキップする。
+
+FPASTE=".build/debug/fpaste"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# ----------------------------------------------------------------
+# ビルドチェック
+# ----------------------------------------------------------------
+if [ ! -x "$FPASTE" ]; then
+  echo "fpaste が見つかりません。先にビルドしてください: swift build -Xswiftc -DDEV"
+  exit 1
+fi
+
+# ----------------------------------------------------------------
+# べき等チェック用ヘルパー
+# ----------------------------------------------------------------
+snippet_exists() {
+  $FPASTE list --json 2>/dev/null | grep -qF "\"$1\"" && return 0 || return 1
+}
+
+add_snippet() {
+  local title="$1"; shift
+  if snippet_exists "$title"; then
+    echo "  skip: $title (exists)"
+  else
+    $FPASTE add "$title" "$@"
+  fi
+}
+
+add_history_text() {
+  $FPASTE history add "$1"
+}
+
+# ----------------------------------------------------------------
+# テスト用ファイル生成
+# ----------------------------------------------------------------
+echo "=== Generating test files ==="
+
+# PNG 画像（Python で最小限の PNG を生成）
+python3 -c "
+import struct, zlib, sys
+def png(w, h, r, g, b):
+    def chunk(t, d):
+        c = t + d
+        return struct.pack('>I', len(d)) + c + struct.pack('>I', zlib.crc32(c) & 0xffffffff)
+    raw = b''
+    for _ in range(h):
+        raw += b'\x00' + bytes([r, g, b]) * w
+    return b'\x89PNG\r\n\x1a\n' + chunk(b'IHDR', struct.pack('>IIBBBBB', w, h, 8, 2, 0, 0, 0)) + chunk(b'IDAT', zlib.compress(raw)) + chunk(b'IEND', b'')
+with open(sys.argv[1], 'wb') as f: f.write(png(120, 80, 230, 70, 70))    # red
+with open(sys.argv[2], 'wb') as f: f.write(png(200, 60, 70, 130, 230))   # blue
+with open(sys.argv[3], 'wb') as f: f.write(png(320, 240, 50, 190, 110))  # green (history)
+" "$TMP/red.png" "$TMP/blue.png" "$TMP/green.png"
+
+# CSV
+cat > "$TMP/employees.csv" << 'CSV'
+name,email,department,role
+Tanaka Taro,tanaka@example.com,Engineering,Lead
+Suzuki Hanako,suzuki@example.com,Design,Senior
+Sato Jiro,sato@example.com,Marketing,Manager
+Yamada Yuki,yamada@example.com,Engineering,Junior
+Kobayashi Mika,kobayashi@example.com,Sales,Director
+CSV
+
+# PDF（最小限の有効な PDF）
+cat > "$TMP/spec.pdf" << 'PDF'
+%PDF-1.0
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/MediaBox[0 0 595 842]/Parent 2 0 R/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 18 Tf 50 780 Td (FuzzyPaste Spec) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+0000000266 00000 n
+0000000360 00000 n
+trailer<</Size 6/Root 1 0 R>>
+startxref
+425
+%%EOF
+PDF
+
+# JSON
+cat > "$TMP/config.json" << 'JSON'
+{
+  "app": "FuzzyPaste",
+  "version": "1.0.0",
+  "settings": {
+    "maxHistory": 500,
+    "theme": "dark",
+    "hotkey": "Cmd+Shift+V",
+    "fuzzyThreshold": 0.6
+  },
+  "features": ["clipboard", "snippets", "fuzzy-search"]
+}
+JSON
+
+echo "  created: red.png, blue.png, green.png, employees.csv, spec.pdf, config.json"
+
+# ----------------------------------------------------------------
+# スニペット投入
+# ----------------------------------------------------------------
+echo ""
+echo "=== Adding snippets ==="
+
+# テキスト（プレースホルダーなし）
+add_snippet "お疲れ様テンプレ" \
+  "$(printf 'お疲れ様です。\n\n表題の件について、ご確認をお願いいたします。\nお忙しいところ恐縮ですが、ご対応いただけますと幸いです。\n\nよろしくお願いいたします。')" \
+  --tag seed --tag メール --tag 定型文
+
+# テキスト（{{}} プレースホルダーあり）
+add_snippet "面談日程メール" \
+  "$(printf '{{name}}様\n\nお世話になっております。\n{{date}}の面談について、下記の通りご案内いたします。\n\n当日はどうぞよろしくお願いいたします。')" \
+  --tag seed --tag メール --tag テンプレ
+
+# 画像（originalFileName あり = ファイルパス指定）
+add_snippet "テスト画像（赤）" \
+  --image "$TMP/red.png" \
+  --tag seed --tag テスト --tag 画像
+
+# 画像（originalFileName あり = 別のファイル）
+add_snippet "テスト画像（青）" \
+  --image "$TMP/blue.png" \
+  --tag seed --tag テスト --tag 画像
+
+# CSV
+add_snippet "社員リスト" \
+  --file "$TMP/employees.csv" \
+  --tag seed --tag データ --tag CSV
+
+# PDF
+add_snippet "仕様書" \
+  --file "$TMP/spec.pdf" \
+  --tag seed --tag ドキュメント --tag PDF
+
+# JSON
+add_snippet "アプリ設定" \
+  --file "$TMP/config.json" \
+  --tag seed --tag 設定 --tag JSON
+
+# ----------------------------------------------------------------
+# クリップボード履歴投入
+# ----------------------------------------------------------------
+echo ""
+echo "=== Adding history ==="
+
+# テキスト（プレーン）
+add_history_text "$(printf 'お疲れ様です。\n先日の件、確認が取れましたのでご連絡いたします。')"
+
+# テキスト（{{}} 付き — 履歴にもテンプレ的なテキストが残るケース）
+add_history_text "$(printf '{{customer_name}} 様\n\nご注文番号: {{order_id}}\n発送予定日: {{ship_date}}\n\n何かご不明な点がございましたらお問い合わせください。')"
+
+# 画像 x2
+$FPASTE history add --image "$TMP/red.png"
+$FPASTE history add --image "$TMP/green.png"
+
+# CSV
+$FPASTE history add --file "$TMP/employees.csv"
+
+# PDF
+$FPASTE history add --file "$TMP/spec.pdf"
+
+# JSON
+$FPASTE history add --file "$TMP/config.json"
+
+echo ""
+echo "=== Done ==="
+$FPASTE list 2>&1 | grep -c "seed" | xargs -I{} echo "Seed snippets: {} items"
+$FPASTE history list 2>&1 | wc -l | xargs -I{} echo "History: {} items"


### PR DESCRIPTION
## Summary
- 検索ウィンドウのセルレイアウトを刷新（サムネ/アイコン右端配置、タイムスタンプ削除、統一セパレーター）
- fpaste CLI に `history` サブコマンド、`add --image / --file` オプションを追加
- ストアの外部変更自動リロード（ファイル変更監視）と `make seed` テストデータ投入を追加

## Changes

### 検索ウィンドウ UI (Closes #42)
- サムネイル・ファイルアイコンを右端に移動、テキスト開始位置を全セルタイプで統一
- タイムスタンプ表示（5m, 2h 等）を全セルから削除
- セパレーターをピクセルアライメント対応の `drawBackground` 描画に変更（太さバラつき解消）
- `selectionHighlightStyle = .none` + 選択/ホバー描画を `drawBackground` に統合

### CLI 拡張・テストデータ (Closes #38)
- `fpaste history list/add/clear` サブコマンドを追加
- `fpaste add --image / --file` でスニペットに画像・ファイルを直接登録可能に
- `make seed` / `scripts/seed.sh` でテキスト・画像・ファイルのテストデータを一括投入
- ストアに `reload()` / `monitoredFileURL` / `lastSaveDate` を追加し、CLI からの変更をアプリが自動検知

## Test plan
- [ ] 検索ウィンドウでテキスト/画像/ファイル/スニペットの表示を確認（サムネ右端、タイムスタンプなし）
- [ ] セパレーターが全行で均一な太さで表示されることを確認
- [ ] 選択行の青いハイライトが正しく表示されることを確認
- [ ] `make seed` でテストデータが投入され、アプリに即時反映されることを確認
- [ ] `fpaste history list / add / clear` が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)