### PR TITLE
feat: PDF の専用ビューアー対応

### DIFF
--- a/Sources/FuzzyPaste/PDFViewerView.swift
+++ b/Sources/FuzzyPaste/PDFViewerView.swift
@@ -1,0 +1,87 @@
+import AppKit
+import PDFKit
+
+/// PDF を表示するビュー。PDFKit の PDFView をラップし、ページ送り・ズーム対応。
+@MainActor
+final class PDFViewerView: NSView {
+    private let pdfView = PDFView()
+    private let pageLabel = NSTextField(labelWithString: "")
+
+    /// PDF ファイル拡張子
+    static let fileExtensions: Set<String> = ["pdf"]
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        wantsLayer = true
+        layer?.cornerRadius = 8
+        layer?.masksToBounds = true
+
+        // PDFView 設定
+        pdfView.autoScales = true
+        pdfView.displayMode = .singlePageContinuous
+        pdfView.displayDirection = .vertical
+        pdfView.backgroundColor = .clear
+        pdfView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(pdfView)
+
+        // ページ数ラベル
+        pageLabel.font = .systemFont(ofSize: 10, weight: .medium)
+        pageLabel.textColor = .tertiaryLabelColor
+        pageLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(pageLabel)
+
+        NSLayoutConstraint.activate([
+            pdfView.topAnchor.constraint(equalTo: topAnchor),
+            pdfView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            pdfView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            pdfView.bottomAnchor.constraint(equalTo: pageLabel.topAnchor, constant: -4),
+
+            pageLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            pageLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4),
+        ])
+    }
+
+    /// PDF ドキュメントをセットして表示する。
+    func setPDF(_ document: PDFDocument) {
+        pdfView.document = document
+        let pageCount = document.pageCount
+        pageLabel.stringValue = "\(pageCount) page\(pageCount == 1 ? "" : "s")"
+
+        // 先頭ページに移動（レイアウト確定後に実行しないと効かない）
+        if let firstPage = document.page(at: 0) {
+            let bounds = firstPage.bounds(for: pdfView.displayBox)
+            let dest = PDFDestination(page: firstPage, at: NSPoint(x: 0, y: bounds.maxY))
+            DispatchQueue.main.async { [weak self] in
+                self?.pdfView.go(to: dest)
+            }
+        }
+    }
+
+    /// 1ページ目のサムネイル画像を返す。ファイル名をキーにキャッシュする。
+    static func thumbnail(for url: URL, size: CGFloat = 128) -> NSImage? {
+        let key = url.lastPathComponent as NSString
+        if let cached = thumbnailCache.object(forKey: key) {
+            return cached
+        }
+        guard let document = PDFDocument(url: url),
+              let page = document.page(at: 0) else { return nil }
+        let image = page.thumbnail(of: NSSize(width: size, height: size), for: .mediaBox)
+        thumbnailCache.setObject(image, forKey: key)
+        return image
+    }
+
+    private static let thumbnailCache: NSCache<NSString, NSImage> = {
+        let cache = NSCache<NSString, NSImage>()
+        cache.countLimit = 50
+        return cache
+    }()
+}

--- a/Sources/FuzzyPaste/QuickLookPanel.swift
+++ b/Sources/FuzzyPaste/QuickLookPanel.swift
@@ -1,5 +1,6 @@
 import AppKit
 import FuzzyPasteCore
+import PDFKit
 
 /// SearchWindow の横に表示される Quick Look パネル。
 /// 選択行を指す吹き出し（三角矢印）付き。上下移動で矢印が追従する。
@@ -18,6 +19,9 @@ final class QuickLookPanel: NSPanel {
         // CSV モード
         static let csvWidth: CGFloat = 560
         static let csvHeight: CGFloat = 440
+        // PDF モード
+        static let pdfWidth: CGFloat = 560
+        static let pdfHeight: CGFloat = 500
         static let minContentSize: CGFloat = 200
         static let imagePadding: CGFloat = 8
         // 共通
@@ -38,6 +42,7 @@ final class QuickLookPanel: NSPanel {
     private let scrollView = NSScrollView()
     private let textView: NSTextView
     private let csvTableView = CSVTableView()
+    private let pdfViewerView = PDFViewerView()
 
     private var arrowOnLeft = true
     private var arrowCenterY: CGFloat = Layout.textHeight / 2
@@ -128,6 +133,11 @@ final class QuickLookPanel: NSPanel {
         csvTableView.isHidden = true
         containerView.addSubview(csvTableView)
 
+        // PDF ビューアー
+        pdfViewerView.translatesAutoresizingMaskIntoConstraints = false
+        pdfViewerView.isHidden = true
+        containerView.addSubview(pdfViewerView)
+
         let p = Layout.imagePadding
         NSLayoutConstraint.activate([
             imageView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: p),
@@ -144,6 +154,11 @@ final class QuickLookPanel: NSPanel {
             csvTableView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: p),
             csvTableView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -p),
             csvTableView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -p),
+
+            pdfViewerView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: p),
+            pdfViewerView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: p),
+            pdfViewerView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -p),
+            pdfViewerView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -p),
         ])
 
         updateMask()
@@ -241,9 +256,8 @@ final class QuickLookPanel: NSPanel {
         applyWindowSize()
 
         imageView.image = image
+        hideAllContentViews()
         imageView.isHidden = false
-        scrollView.isHidden = true
-        csvTableView.isHidden = true
     }
 
     /// テキストをセットし、パネルサイズを固定サイズに戻す。
@@ -254,9 +268,8 @@ final class QuickLookPanel: NSPanel {
         applyWindowSize()
 
         textView.string = text
+        hideAllContentViews()
         scrollView.isHidden = false
-        imageView.isHidden = true
-        csvTableView.isHidden = true
     }
 
     /// CSV パース結果をテーブル形式で表示する。
@@ -266,9 +279,27 @@ final class QuickLookPanel: NSPanel {
         applyWindowSize()
 
         csvTableView.setCSV(result)
+        hideAllContentViews()
         csvTableView.isHidden = false
-        scrollView.isHidden = true
+    }
+
+    /// PDF ドキュメントをビューアーで表示する。
+    func showPDF(_ document: PDFDocument) {
+        currentContentWidth = Layout.pdfWidth
+        currentContentHeight = Layout.pdfHeight
+        applyWindowSize()
+
+        pdfViewerView.setPDF(document)
+        hideAllContentViews()
+        pdfViewerView.isHidden = false
+    }
+
+    /// 全コンテンツビューを非表示にする。各 show メソッドで呼び出し後に対象だけ表示する。
+    private func hideAllContentViews() {
         imageView.isHidden = true
+        scrollView.isHidden = true
+        csvTableView.isHidden = true
+        pdfViewerView.isHidden = true
     }
 
     /// ウィンドウフレーム確定後にテキストを再レイアウトし、先頭にスクロールする。

--- a/Sources/FuzzyPaste/SearchWindow.swift
+++ b/Sources/FuzzyPaste/SearchWindow.swift
@@ -1,5 +1,6 @@
 import AppKit
 import FuzzyPasteCore
+import PDFKit
 
 // MARK: - カスタム行ビュー（角丸セレクション + ホバーエフェクト）
 
@@ -1264,7 +1265,14 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
         }
 
         iconView.isHidden = false
-        iconView.image = fileStore?.icon(for: meta)
+        // PDF は1ページ目のサムネイルを表示（キャッシュ付き）
+        if PDFViewerView.fileExtensions.contains(meta.fileExtension.lowercased()),
+           let store = fileStore,
+           let thumb = PDFViewerView.thumbnail(for: store.fileURL(for: meta.fileName), size: layout.thumbSize) {
+            iconView.image = thumb
+        } else {
+            iconView.image = fileStore?.icon(for: meta)
+        }
         titleLabel.stringValue = meta.originalFileName
 
         let sizeStr = formatFileSize(meta.fileSizeBytes)
@@ -1559,7 +1567,7 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
         case .clip(let clipItem):
             switch clipItem.content {
             case .text(let text):
-                showTextOrCSV(text, in: panel)
+                showTextPreview(text, in: panel)
             case .image(let meta):
                 if let store = imageStore,
                    let image = NSImage(contentsOf: store.imageURL(for: meta.fileName)) {
@@ -1568,12 +1576,12 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
                     panel.showImage(thumb)
                 }
             case .file(let meta):
-                showFileOrCSV(meta, in: panel)
+                showFilePreview(meta, in: panel)
             }
         case .snippet(let snippet):
             switch snippet.content {
             case .text(let text):
-                showTextOrCSV(text, in: panel)
+                showTextPreview(text, in: panel)
             case .image(let meta):
                 if let store = imageStore,
                    let image = NSImage(contentsOf: store.imageURL(for: meta.fileName)) {
@@ -1582,13 +1590,13 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
                     panel.showImage(thumb)
                 }
             case .file(let meta):
-                showFileOrCSV(meta, in: panel)
+                showFilePreview(meta, in: panel)
             }
         }
     }
 
-    /// テキストが CSV なら CSV ビューアー、そうでなければテキストとして表示する。
-    private func showTextOrCSV(_ text: String, in panel: QuickLookPanel) {
+    /// テキストが CSV なら CSV ビューアー、それ以外はテキストとして表示する。
+    private func showTextPreview(_ text: String, in panel: QuickLookPanel) {
         if let result = CSVParser.parseIfCSV(text) {
             panel.showCSV(result)
         } else {
@@ -1596,13 +1604,17 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
         }
     }
 
-    /// ファイルが CSV/TSV なら内容を読み取って CSV ビューアーで表示する。
-    private func showFileOrCSV(_ meta: FileMetadata, in panel: QuickLookPanel) {
+    /// ファイルの種類に応じた専用ビューアーで表示する（CSV/PDF）。非対応ならアイコン表示。
+    private func showFilePreview(_ meta: FileMetadata, in panel: QuickLookPanel) {
         guard let store = fileStore else { return }
-        if CSVParser.fileExtensions.contains(meta.fileExtension.lowercased()),
+        let ext = meta.fileExtension.lowercased()
+        if CSVParser.fileExtensions.contains(ext),
            let text = try? String(contentsOf: store.fileURL(for: meta.fileName), encoding: .utf8),
            let result = CSVParser.parseIfCSV(text) {
             panel.showCSV(result)
+        } else if PDFViewerView.fileExtensions.contains(ext),
+                  let document = PDFDocument(url: store.fileURL(for: meta.fileName)) {
+            panel.showPDF(document)
         } else {
             panel.showFileIcon(store.icon(for: meta))
         }

--- a/Sources/FuzzyPaste/SnippetManagerWindow.swift
+++ b/Sources/FuzzyPaste/SnippetManagerWindow.swift
@@ -1,5 +1,6 @@
 import AppKit
 import FuzzyPasteCore
+import PDFKit
 import UniformTypeIdentifiers
 
 /// スニペット一覧の行ビュー。角丸選択ハイライト + ホバーエフェクト。
@@ -567,6 +568,7 @@ final class SnippetManagerWindow: NSWindow, NSTableViewDataSource, NSTableViewDe
     private let fileCardView = NSView()
     private let fileClearButton = NSButton()
     private let fileCsvTableView = CSVTableView()
+    private let filePdfViewerView = PDFViewerView()
 
     // ドロップゾーン（画像/ファイル選択用）
     private let imageDropZone = DropZoneView(kind: .image)
@@ -1008,6 +1010,11 @@ final class SnippetManagerWindow: NSWindow, NSTableViewDataSource, NSTableViewDe
         fileCsvTableView.isHidden = true
         fileWrapper.addSubview(fileCsvTableView)
 
+        // PDF プレビュービューアー
+        filePdfViewerView.translatesAutoresizingMaskIntoConstraints = false
+        filePdfViewerView.isHidden = true
+        fileWrapper.addSubview(filePdfViewerView)
+
         // ドロップゾーン（ファイル）
         fileDropZone.onFileSelected = { [weak self] url in
             self?.handleDroppedFile(url, forType: .file)
@@ -1144,6 +1151,12 @@ final class SnippetManagerWindow: NSWindow, NSTableViewDataSource, NSTableViewDe
             fileCsvTableView.trailingAnchor.constraint(equalTo: fileWrapper.trailingAnchor, constant: -Layout.inputPadding),
             fileCsvTableView.bottomAnchor.constraint(equalTo: fileWrapper.bottomAnchor, constant: -Layout.inputPadding),
 
+            // PDF プレビュービューアー
+            filePdfViewerView.topAnchor.constraint(equalTo: fileCardView.bottomAnchor, constant: 8),
+            filePdfViewerView.leadingAnchor.constraint(equalTo: fileWrapper.leadingAnchor, constant: Layout.inputPadding),
+            filePdfViewerView.trailingAnchor.constraint(equalTo: fileWrapper.trailingAnchor, constant: -Layout.inputPadding),
+            filePdfViewerView.bottomAnchor.constraint(equalTo: fileWrapper.bottomAnchor, constant: -Layout.inputPadding),
+
             // ファイルドロップゾーン
             fileDropZone.topAnchor.constraint(equalTo: fileContentContainer.topAnchor),
             fileDropZone.leadingAnchor.constraint(equalTo: fileContentContainer.leadingAnchor),
@@ -1207,6 +1220,7 @@ final class SnippetManagerWindow: NSWindow, NSTableViewDataSource, NSTableViewDe
         imageContentContainer.isHidden = true
         fileContentContainer.isHidden = true
         fileCsvTableView.isHidden = true
+        filePdfViewerView.isHidden = true
 
         switch display {
         case .text:
@@ -1468,7 +1482,7 @@ final class SnippetManagerWindow: NSWindow, NSTableViewDataSource, NSTableViewDe
                 let ext = meta.fileExtension.uppercased()
                 let size = formatFileSize(meta.fileSizeBytes)
                 fileInfoLabel.stringValue = ext.isEmpty ? size : "\(ext) · \(size)"
-                updateCsvPreview(for: meta)
+                updateFilePreview(for: meta)
             }
         } else {
             editFormContainer.isHidden = true
@@ -1641,15 +1655,23 @@ final class SnippetManagerWindow: NSWindow, NSTableViewDataSource, NSTableViewDe
     @objc private func clearImageContent() { confirmAndClearContent(label: "画像") }
     @objc private func clearFileContent() { confirmAndClearContent(label: "ファイル") }
 
-    /// ファイルが CSV なら CSV テーブルを表示する。
-    private func updateCsvPreview(for meta: FileMetadata) {
-        if CSVParser.fileExtensions.contains(meta.fileExtension.lowercased()),
+    /// ファイルが CSV/PDF なら専用ビューアーを表示する。
+    private func updateFilePreview(for meta: FileMetadata) {
+        let ext = meta.fileExtension.lowercased()
+        if CSVParser.fileExtensions.contains(ext),
            let text = try? String(contentsOf: fileStore.fileURL(for: meta.fileName), encoding: .utf8),
            let result = CSVParser.parseIfCSV(text) {
             fileCsvTableView.setCSV(result)
             fileCsvTableView.isHidden = false
+            filePdfViewerView.isHidden = true
+        } else if PDFViewerView.fileExtensions.contains(ext),
+                  let document = PDFDocument(url: fileStore.fileURL(for: meta.fileName)) {
+            filePdfViewerView.setPDF(document)
+            filePdfViewerView.isHidden = false
+            fileCsvTableView.isHidden = true
         } else {
             fileCsvTableView.isHidden = true
+            filePdfViewerView.isHidden = true
         }
     }
 


### PR DESCRIPTION
## Summary
- PDFKit (`PDFView`) を使用した PDF ビューアーを追加（ページスクロール・ズーム対応）
- 検索ウィンドウの Quick Look プレビュー（スペースキー）で PDF を表示
- スニペット管理ウィンドウのファイルプレビューで PDF を表示
- 検索結果セルで PDF 1ページ目のサムネイルを表示（キャッシュ付き）

## 変更ファイル
| ファイル | 変更内容 |
|----------|----------|
| `PDFViewerView.swift` (新規) | PDFView ラッパー + サムネイル生成・キャッシュ |
| `QuickLookPanel.swift` | PDF モード追加 + `hideAllContentViews()` で DRY 化 |
| `SearchWindow.swift` | PDF ルーティング + セルサムネイル + メソッド名改善 |
| `SnippetManagerWindow.swift` | PDF プレビュー追加 + メソッド名改善 |

## Test plan
- [ ] PDF ファイルをコピーしてクリップボード履歴に追加
- [ ] 検索ウィンドウでスペースキーを押して PDF プレビューを確認（先頭ページが表示されること）
- [ ] 複数ページ PDF でスクロール・ズームが動作すること
- [ ] 検索結果セルに PDF 1ページ目のサムネイルが表示されること
- [ ] スニペット管理で PDF ファイルスニペットのプレビューが表示されること
- [ ] テキスト・画像・CSV の既存プレビューが壊れていないこと

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)