### PR TITLE
perf: PDF 読み込みをバックグラウンド化しキャッシュを追加

### DIFF
--- a/Sources/FuzzyPaste/PDFViewerView.swift
+++ b/Sources/FuzzyPaste/PDFViewerView.swift
@@ -6,6 +6,8 @@ import PDFKit
 final class PDFViewerView: NSView {
     private let pdfView = PDFView()
     private let pageLabel = NSTextField(labelWithString: "")
+    /// 読み込み中の PDF を識別し、完了時に別の PDF に切り替わっていたら破棄する
+    private var currentLoadingKey: String?
 
     /// PDF ファイル拡張子
     static let fileExtensions: Set<String> = ["pdf"]
@@ -50,8 +52,33 @@ final class PDFViewerView: NSView {
         ])
     }
 
+    /// URL から PDF をバックグラウンドで読み込んで表示する。
+    /// キャッシュ済みの場合は即座に表示する。
+    func loadPDF(from url: URL) {
+        let cacheKey = url.lastPathComponent
+        if let cached = Self.documentCache.object(forKey: cacheKey as NSString) {
+            applyDocument(cached)
+            return
+        }
+        // 読み込み完了時に別の PDF に切り替わっていた場合は破棄する
+        currentLoadingKey = cacheKey
+        let path = url.path
+        Task.detached(priority: .userInitiated) {
+            guard let document = PDFDocument(url: URL(fileURLWithPath: path)) else { return }
+            await MainActor.run { [weak self] in
+                guard let self, self.currentLoadingKey == cacheKey else { return }
+                Self.documentCache.setObject(document, forKey: cacheKey as NSString)
+                self.applyDocument(document)
+            }
+        }
+    }
+
     /// PDF ドキュメントをセットして表示する。
     func setPDF(_ document: PDFDocument) {
+        applyDocument(document)
+    }
+
+    private func applyDocument(_ document: PDFDocument) {
         pdfView.document = document
         let pageCount = document.pageCount
         pageLabel.stringValue = "\(pageCount) page\(pageCount == 1 ? "" : "s")"
@@ -86,6 +113,12 @@ final class PDFViewerView: NSView {
     private static let thumbnailCache: NSCache<NSString, NSImage> = {
         let cache = NSCache<NSString, NSImage>()
         cache.countLimit = 50
+        return cache
+    }()
+
+    private static let documentCache: NSCache<NSString, PDFDocument> = {
+        let cache = NSCache<NSString, PDFDocument>()
+        cache.countLimit = 10
         return cache
     }()
 }

--- a/Sources/FuzzyPaste/QuickLookPanel.swift
+++ b/Sources/FuzzyPaste/QuickLookPanel.swift
@@ -294,6 +294,17 @@ final class QuickLookPanel: NSPanel {
         pdfViewerView.isHidden = false
     }
 
+    /// URL から PDF をバックグラウンドで読み込んで表示する。
+    func loadPDF(from url: URL) {
+        currentContentWidth = Layout.pdfWidth
+        currentContentHeight = Layout.pdfHeight
+        applyWindowSize()
+
+        pdfViewerView.loadPDF(from: url)
+        hideAllContentViews()
+        pdfViewerView.isHidden = false
+    }
+
     /// 全コンテンツビューを非表示にする。各 show メソッドで呼び出し後に対象だけ表示する。
     private func hideAllContentViews() {
         imageView.isHidden = true

--- a/Sources/FuzzyPaste/SearchWindow.swift
+++ b/Sources/FuzzyPaste/SearchWindow.swift
@@ -1,6 +1,5 @@
 import AppKit
 import FuzzyPasteCore
-import PDFKit
 
 // MARK: - カスタム行ビュー（角丸セレクション + ホバーエフェクト）
 
@@ -1612,9 +1611,8 @@ final class SearchWindow: NSPanel, NSTextFieldDelegate, NSTableViewDataSource, N
            let text = try? String(contentsOf: store.fileURL(for: meta.fileName), encoding: .utf8),
            let result = CSVParser.parseIfCSV(text) {
             panel.showCSV(result)
-        } else if PDFViewerView.fileExtensions.contains(ext),
-                  let document = PDFDocument(url: store.fileURL(for: meta.fileName)) {
-            panel.showPDF(document)
+        } else if PDFViewerView.fileExtensions.contains(ext) {
+            panel.loadPDF(from: store.fileURL(for: meta.fileName))
         } else {
             panel.showFileIcon(store.icon(for: meta))
         }

--- a/Sources/FuzzyPaste/SnippetManagerWindow.swift
+++ b/Sources/FuzzyPaste/SnippetManagerWindow.swift
@@ -1,6 +1,5 @@
 import AppKit
 import FuzzyPasteCore
-import PDFKit
 import UniformTypeIdentifiers
 
 /// スニペット一覧の行ビュー。角丸選択ハイライト + ホバーエフェクト。
@@ -1911,9 +1910,8 @@ final class SnippetManagerWindow: NSWindow, NSTableViewDataSource, NSTableViewDe
             fileCsvTableView.setCSV(result)
             fileCsvTableView.isHidden = false
             filePdfViewerView.isHidden = true
-        } else if PDFViewerView.fileExtensions.contains(ext),
-                  let document = PDFDocument(url: fileStore.fileURL(for: meta.fileName)) {
-            filePdfViewerView.setPDF(document)
+        } else if PDFViewerView.fileExtensions.contains(ext) {
+            filePdfViewerView.loadPDF(from: fileStore.fileURL(for: meta.fileName))
             filePdfViewerView.isHidden = false
             fileCsvTableView.isHidden = true
         } else {


### PR DESCRIPTION
## Summary
- `PDFDocument` の生成（ファイル I/O + パース）を `Task.detached` でバックグラウンド実行し、メインスレッドのブロッキングを解消
- `NSCache<NSString, PDFDocument>`（上限10件）を追加し、同じ PDF の2回目以降は即座に表示
- 読み込み完了時に別の PDF に切り替わっていた場合のレースコンディションを `currentLoadingKey` で防止

## Test plan
- [ ] PDF スニペットを選択 → 描画時の引っかかりが軽減されていること
- [ ] PDF スニペットを選択→別スニペット→同じ PDF スニペットに戻る → 2回目は即表示されること
- [ ] PDF スニペットを素早く切り替え → 古い PDF が一瞬表示されないこと
- [ ] SearchWindow の QuickLook で PDF が正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)