### PR TITLE
feat: Frecency スコアリングで検索結果の並び順を最適化

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,5 +28,10 @@ let package = Package(
             ],
             path: "Sources/fpaste"
         ),
+        .testTarget(
+            name: "FuzzyPasteCoreTests",
+            dependencies: ["FuzzyPasteCore"],
+            path: "Tests/FuzzyPasteCoreTests"
+        ),
     ]
 )

--- a/Sources/FuzzyPaste/AppDelegate.swift
+++ b/Sources/FuzzyPaste/AppDelegate.swift
@@ -201,6 +201,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         window.onPaste = { [weak self] item, previousApp in
             guard let self else { return }
             self.clipboardMonitor.ignoreNextChange()
+            self.historyStore.recordUse(id: item.id)
             switch item.content {
             case .text(let text):
                 PasteHelper.paste(text, previousApp: previousApp)
@@ -215,6 +216,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         window.onMultiPaste = { [weak self] items, previousApp in
             guard let self else { return }
             self.clipboardMonitor.ignoreNextChange()
+            self.historyStore.recordUses(ids: items.map(\.id))
             // テキストアイテムのみ抽出し、選択順に改行で結合してペースト
             let texts = items.compactMap { item -> String? in
                 if case .text(let text) = item.content { return text }
@@ -226,6 +228,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         window.onCopy = { [weak self] item in
             guard let self else { return }
             self.clipboardMonitor.ignoreNextChange()
+            self.historyStore.recordUse(id: item.id)
             switch item.content {
             case .text(let text):
                 PasteHelper.copyToClipboard(text)

--- a/Sources/FuzzyPasteCore/FuzzyMatcher.swift
+++ b/Sources/FuzzyPasteCore/FuzzyMatcher.swift
@@ -39,15 +39,34 @@ public enum FuzzyMatcher {
         return score
     }
 
+    // MARK: - Frecency
+
+    /// frecency スコアを計算する。使用回数と最終使用日時から算出。
+    /// 半減期 72 時間で連続減衰する。
+    public static func frecencyScore(useCount: Int, lastUsedAt: Date?, now: Date = Date()) -> Double {
+        guard useCount > 0, let lastUsed = lastUsedAt else { return 0 }
+        let hoursSinceLastUse = max(0, now.timeIntervalSince(lastUsed) / 3600)
+        let decayFactor = pow(0.5, hoursSinceLastUse / 72.0)
+        return Double(useCount) * decayFactor
+    }
+
+    /// frecency スコアの重み（fuzzy スコアに対する比率）
+    private static let frecencyWeight: Double = 0.5
+
+    /// fuzzy スコアと frecency スコアを合成する。
+    private static func combinedScore(fuzzy: Int, clip: ClipItem) -> Double {
+        Double(fuzzy) + frecencyWeight * frecencyScore(useCount: clip.useCount, lastUsedAt: clip.lastUsedAt)
+    }
+
     /// クエリでアイテム一覧をフィルタリングし、スコア降順でソートして返す。
     /// クエリが空の場合は全件をそのまま返す。
     public static func filter(query: String, items: [ClipItem]) -> [ClipItem] {
         if query.isEmpty { return items }
         return items
-            .compactMap { item -> (item: ClipItem, score: Int)? in
+            .compactMap { item -> (item: ClipItem, score: Double)? in
                 guard let text = item.text,
-                      let score = match(query: query, target: text) else { return nil }
-                return (item, score)
+                      let fuzzy = match(query: query, target: text) else { return nil }
+                return (item, combinedScore(fuzzy: fuzzy, clip: item))
             }
             .sorted { $0.score > $1.score }
             .map(\.item)
@@ -67,10 +86,10 @@ public enum FuzzyMatcher {
             if query.isEmpty {
                 return filtered.map { .snippet($0) }
             }
-            var scored: [(item: SearchResultItem, score: Int)] = []
+            var scored: [(item: SearchResultItem, score: Double)] = []
             for snippet in filtered {
                 let best = bestSnippetScore(query: query, snippet: snippet)
-                if let s = best { scored.append((.snippet(snippet), s)) }
+                if let s = best { scored.append((.snippet(snippet), Double(s))) }
             }
             return scored.sorted { $0.score > $1.score }.map(\.item)
         }
@@ -79,13 +98,13 @@ public enum FuzzyMatcher {
             return clips.map { SearchResultItem.clip($0) }
         }
 
-        var scored: [(item: SearchResultItem, score: Int)] = []
+        var scored: [(item: SearchResultItem, score: Double)] = []
 
         for clip in clips {
             switch clip.content {
             case .text(let text):
                 if let score = match(query: query, target: text) {
-                    scored.append((.clip(clip), score))
+                    scored.append((.clip(clip), combinedScore(fuzzy: score, clip: clip)))
                 }
             case .image(let meta):
                 // 画像は originalFileName と ocrText（行単位）を検索対象にする
@@ -99,18 +118,18 @@ public enum FuzzyMatcher {
                     bestScore = max(bestScore ?? 0, s)
                 }
                 if let s = bestScore {
-                    scored.append((.clip(clip), s))
+                    scored.append((.clip(clip), combinedScore(fuzzy: s, clip: clip)))
                 }
             case .file(let meta):
                 if let score = match(query: query, target: meta.originalFileName) {
-                    scored.append((.clip(clip), score))
+                    scored.append((.clip(clip), combinedScore(fuzzy: score, clip: clip)))
                 }
             }
         }
 
         for snippet in activeSnippets {
             if let bestScore = bestSnippetScore(query: query, snippet: snippet) {
-                scored.append((.snippet(snippet), bestScore))
+                scored.append((.snippet(snippet), Double(bestScore)))
             }
         }
 

--- a/Sources/FuzzyPasteCore/HistoryStore.swift
+++ b/Sources/FuzzyPasteCore/HistoryStore.swift
@@ -53,40 +53,67 @@ extension ClipContent: Codable {}
 
 /// クリップボード履歴の1エントリ。
 /// JSON で永続化するため Codable に準拠。
-public struct ClipItem: Codable, Identifiable, Sendable {
+public struct ClipItem: Identifiable, Sendable {
     public let id: UUID
     public let content: ClipContent
     public let copiedAt: Date
+    /// ペースト/コピーされた回数。frecency スコアの計算に使用。
+    public var useCount: Int
+    /// 最後にペースト/コピーされた日時。frecency スコアの減衰計算に使用。
+    public var lastUsedAt: Date?
 
     public init(text: String) {
         self.id = UUID()
         self.content = .text(text)
         self.copiedAt = Date()
+        self.useCount = 0
+        self.lastUsedAt = nil
     }
 
     public init(imageMetadata: ImageMetadata) {
         self.id = UUID()
         self.content = .image(imageMetadata)
         self.copiedAt = Date()
+        self.useCount = 0
+        self.lastUsedAt = nil
     }
 
     public init(fileMetadata: FileMetadata) {
         self.id = UUID()
         self.content = .file(fileMetadata)
         self.copiedAt = Date()
+        self.useCount = 0
+        self.lastUsedAt = nil
     }
 
     /// 既存アイテムの内容を置き換えて再構築する。OCR テキスト更新等で使用。
-    init(id: UUID, content: ClipContent, copiedAt: Date) {
+    init(id: UUID, content: ClipContent, copiedAt: Date, useCount: Int = 0, lastUsedAt: Date? = nil) {
         self.id = id
         self.content = content
         self.copiedAt = copiedAt
+        self.useCount = useCount
+        self.lastUsedAt = lastUsedAt
     }
 
     /// テキストコンテンツを返す。画像・ファイルの場合は nil。
     public var text: String? {
         if case .text(let string) = content { return string }
         return nil
+    }
+}
+
+extension ClipItem: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case id, content, copiedAt, useCount, lastUsedAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        content = try container.decode(ClipContent.self, forKey: .content)
+        copiedAt = try container.decode(Date.self, forKey: .copiedAt)
+        useCount = try container.decodeIfPresent(Int.self, forKey: .useCount) ?? 0
+        lastUsedAt = try container.decodeIfPresent(Date.self, forKey: .lastUsedAt)
     }
 }
 
@@ -115,10 +142,17 @@ public final class HistoryStore {
 
     /// テキストアイテムを追加。同じテキストが既にあれば重複排除して先頭に移動。
     /// 空白・改行・タブのみのテキストは無視する。
+    /// 重複排除時は frecency データ（useCount / lastUsedAt）を引き継ぐ。
     public func add(_ text: String) {
         guard !text.allSatisfy(\.isWhitespace) else { return }
+        let existing = items.first { $0.text == text }
         items.removeAll { $0.text == text }
-        items.insert(ClipItem(text: text), at: 0)
+        var newItem = ClipItem(text: text)
+        if let existing {
+            newItem.useCount = existing.useCount
+            newItem.lastUsedAt = existing.lastUsedAt
+        }
+        items.insert(newItem, at: 0)
         trimAndSave()
     }
 
@@ -142,8 +176,28 @@ public final class HistoryStore {
         }) else { return }
         guard case .image(var meta) = items[index].content else { return }
         meta.ocrText = text
-        items[index] = ClipItem(id: items[index].id, content: .image(meta), copiedAt: items[index].copiedAt)
+        let old = items[index]
+        items[index] = ClipItem(id: old.id, content: .image(meta), copiedAt: old.copiedAt,
+                                useCount: old.useCount, lastUsedAt: old.lastUsedAt)
         save()
+    }
+
+    /// 使用回数と最終使用日時を更新する。ペースト/コピー時に呼ぶ。
+    public func recordUse(id: UUID) {
+        recordUses(ids: [id])
+    }
+
+    /// 複数アイテムの使用回数と最終使用日時を一括更新する。マルチペースト時に使用。
+    public func recordUses(ids: [UUID]) {
+        let idSet = Set(ids)
+        let now = Date()
+        var updated = false
+        for index in items.indices where idSet.contains(items[index].id) {
+            items[index].useCount += 1
+            items[index].lastUsedAt = now
+            updated = true
+        }
+        if updated { save() }
     }
 
     /// 最大件数を変更し、超過分があればトリムして保存。

--- a/Tests/FuzzyPasteCoreTests/FuzzyMatcherTests.swift
+++ b/Tests/FuzzyPasteCoreTests/FuzzyMatcherTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+@testable import FuzzyPasteCore
+
+// MARK: - Fuzzy Match 基本動作
+
+struct FuzzyMatcherMatchTests {
+    @Test("完全一致する文字列はマッチする")
+    func exactMatch() {
+        let score = FuzzyMatcher.match(query: "hello", target: "hello")
+        #expect(score != nil)
+    }
+
+    @Test("クエリの各文字が順番通りに含まれていればマッチする")
+    func partialMatch() {
+        // "hlo" → h...l...o の順で "hello world" に含まれる
+        let score = FuzzyMatcher.match(query: "hlo", target: "hello world")
+        #expect(score != nil)
+    }
+
+    @Test("対象文字列に含まれない文字があればマッチしない")
+    func noMatch() {
+        let score = FuzzyMatcher.match(query: "xyz", target: "hello")
+        #expect(score == nil)
+    }
+
+    @Test("クエリの文字が順番通りでなければマッチしない")
+    func wrongOrder() {
+        // "olh" は hello 内で o→l→h の順に見つからない
+        let score = FuzzyMatcher.match(query: "olh", target: "hello")
+        #expect(score == nil)
+    }
+
+    @Test("大文字小文字を区別しない")
+    func caseInsensitive() {
+        let score = FuzzyMatcher.match(query: "HELLO", target: "hello world")
+        #expect(score != nil)
+    }
+
+    @Test("空クエリは全てにマッチする")
+    func emptyQuery() {
+        let score = FuzzyMatcher.match(query: "", target: "hello")
+        #expect(score != nil)
+    }
+
+    @Test("連続一致はバラバラ一致よりスコアが高い")
+    func consecutiveBonusHigherScore() {
+        // "hel" は "hello" で連続一致 → 高スコア
+        // "hlo" は "hello world" で途切れる → 低スコア
+        let consecutive = FuzzyMatcher.match(query: "hel", target: "hello")!
+        let scattered = FuzzyMatcher.match(query: "hlo", target: "hello world")!
+        #expect(consecutive > scattered)
+    }
+}
+
+// MARK: - フィルタリング
+
+struct FuzzyMatcherFilterTests {
+    private func makeClip(_ text: String, useCount: Int = 0, lastUsedAt: Date? = nil) -> ClipItem {
+        ClipItem(id: UUID(), content: .text(text), copiedAt: Date(), useCount: useCount, lastUsedAt: lastUsedAt)
+    }
+
+    @Test("空クエリは全件をそのまま返す")
+    func emptyQueryReturnsAll() {
+        let items = [makeClip("aaa"), makeClip("bbb")]
+        let result = FuzzyMatcher.filter(query: "", items: items)
+        #expect(result.count == 2)
+    }
+
+    @Test("マッチしないアイテムは除外される")
+    func filtersNonMatching() {
+        let items = [makeClip("hello world"), makeClip("goodbye")]
+        let result = FuzzyMatcher.filter(query: "hlo", items: items)
+        #expect(result.count == 1)
+        #expect(result[0].text == "hello world")
+    }
+
+    @Test("連続一致が多いアイテムが上位にソートされる")
+    func sortsByScore() {
+        // "hello" は完全一致で高スコア、"h_e_l_l_o" はバラバラ一致で低スコア
+        let items = [makeClip("h_e_l_l_o"), makeClip("hello")]
+        let result = FuzzyMatcher.filter(query: "hello", items: items)
+        #expect(result[0].text == "hello")
+    }
+}
+
+// MARK: - Frecency スコア計算
+
+struct FrecencyScoreTests {
+    @Test("使用回数 0 のアイテムはスコア 0")
+    func zeroUseCount() {
+        let score = FuzzyMatcher.frecencyScore(useCount: 0, lastUsedAt: Date())
+        #expect(score == 0)
+    }
+
+    @Test("lastUsedAt が nil のアイテムはスコア 0")
+    func nilLastUsedAt() {
+        let score = FuzzyMatcher.frecencyScore(useCount: 5, lastUsedAt: nil)
+        #expect(score == 0)
+    }
+
+    @Test("直前に使ったアイテムは useCount がほぼそのままスコアになる")
+    func justUsed() {
+        let score = FuzzyMatcher.frecencyScore(useCount: 10, lastUsedAt: Date())
+        #expect(score > 9.9 && score <= 10.0)
+    }
+
+    @Test("72 時間経過でスコアが半減する")
+    func decaysOverTime() {
+        let now = Date()
+        let recent = FuzzyMatcher.frecencyScore(useCount: 10, lastUsedAt: now, now: now)
+        let old = FuzzyMatcher.frecencyScore(
+            useCount: 10,
+            lastUsedAt: now.addingTimeInterval(-72 * 3600),
+            now: now
+        )
+        #expect(recent > old)
+        #expect(abs(old - 5.0) < 0.01)
+    }
+
+    @Test("144 時間（半減期 x 2）で 1/4 に減衰する")
+    func halfLifeAt72Hours() {
+        let now = Date()
+        let score = FuzzyMatcher.frecencyScore(
+            useCount: 100,
+            lastUsedAt: now.addingTimeInterval(-144 * 3600),
+            now: now
+        )
+        // 100 * (0.5)^2 = 25
+        #expect(abs(score - 25.0) < 0.01)
+    }
+}
+
+// MARK: - Frecency が検索順位に反映されることの検証
+
+struct FrecencyRankingTests {
+    private func makeClip(_ text: String, useCount: Int = 0, lastUsedAt: Date? = nil) -> ClipItem {
+        ClipItem(id: UUID(), content: .text(text), copiedAt: Date(), useCount: useCount, lastUsedAt: lastUsedAt)
+    }
+
+    @Test("fuzzy スコアが同程度なら、使用頻度が高いアイテムが上位になる")
+    func frequentlyUsedItemRanksHigher() {
+        let now = Date()
+        let frequent = makeClip("apple pie recipe", useCount: 20, lastUsedAt: now)
+        let unused = makeClip("apple juice recipe", useCount: 0)
+        let results = FuzzyMatcher.filter(query: "apple", items: [unused, frequent])
+        #expect(results[0].text == "apple pie recipe")
+    }
+
+    @Test("長期間使われていないアイテムは減衰して順位が下がる")
+    func oldUsageDecaysAndLosesPriority() {
+        let now = Date()
+        // 720 時間前 = 半減期 x 10 → 使用回数 5 のスコアはほぼ 0 に減衰
+        let oldFrequent = makeClip("apple pie recipe", useCount: 5,
+                                   lastUsedAt: now.addingTimeInterval(-720 * 3600))
+        let recentOnce = makeClip("apple juice recipe", useCount: 3, lastUsedAt: now)
+        let results = FuzzyMatcher.filter(query: "apple", items: [oldFrequent, recentOnce])
+        #expect(results[0].text == "apple juice recipe")
+    }
+
+    @Test("filterMixed でもクリップに frecency が適用される")
+    func filterMixedAppliesFrecencyToClips() {
+        let now = Date()
+        let frequent = makeClip("git commit message", useCount: 15, lastUsedAt: now)
+        let unused = makeClip("git commit hash", useCount: 0)
+        let results = FuzzyMatcher.filterMixed(query: "git commit", clips: [unused, frequent], snippets: [])
+        #expect(results[0].clipItem?.text == "git commit message")
+    }
+
+    @Test("空クエリ時は frecency を無視して配列順（時系列）を維持する")
+    func emptyQueryIgnoresFrecency() {
+        let now = Date()
+        let first = makeClip("first item", useCount: 0)
+        let second = makeClip("second item", useCount: 100, lastUsedAt: now)
+        let results = FuzzyMatcher.filterMixed(query: "", clips: [first, second], snippets: [])
+        #expect(results[0].clipItem?.text == "first item")
+    }
+}


### PR DESCRIPTION
## Summary
- クリップの使用頻度と最終使用日時を検索スコアに加味し、よく使うアイテムが上位に表示されるようにする
- 半減期72時間の連続減衰モデルを採用（Firefox URL バー等と同様のアプローチ）
- FuzzyMatcher のユニットテスト基盤を新規構築（19件）

## 変更内容
- `ClipItem` に `useCount` / `lastUsedAt` を追加（`decodeIfPresent` で既存 JSON と後方互換）
- ペースト/コピー時に `recordUse` / `recordUses` で使用履歴を記録
- `FuzzyMatcher` に `frecencyScore()` / `combinedScore()` を追加し、検索結果のランキングに反映
- 空クエリ時は従来通り時系列順を維持（frecency 適用なし）
- テキスト重複排除時に frecency データを引き継ぐ
- マルチペースト時はバッチ save で効率化

## Test plan
- [x] `swift build` ビルド通過
- [x] `swift test` 19件全通過
- [ ] 手動確認: 同じアイテムを複数回ペーストした後、検索で上位に表示されること
- [ ] 手動確認: 既存の history.json で起動してもクラッシュしないこと（後方互換性）
- [ ] 手動確認: 空クエリ時の表示順が従来通り（時系列順）であること

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)